### PR TITLE
Rework structure and improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Next, add the `TransformInterpolationPlugin`:
 
 ```rust
 use bevy::prelude::*;
-use bevy_transform_interpolation::*;
+use bevy_transform_interpolation::prelude::*;
 
 fn main() {
     App::new()
@@ -79,21 +79,21 @@ You can choose to interpolate transform, rotation, or scale individually, or use
 
 ```rust
 use bevy::prelude::*;
-use bevy_transform_interpolation::*;
+use bevy_transform_interpolation::prelude::*;
 
 fn setup(mut commands: Commands) {
     // Only interpolate translation.
-    commands.spawn((TransformBundle::default(), TranslationInterpolation));
+    commands.spawn((Transform::default(), TranslationInterpolation));
     
     // Only interpolate rotation.
-    commands.spawn((TransformBundle::default(), RotationInterpolation));
+    commands.spawn((Transform::default(), RotationInterpolation));
     
     // Only interpolate scale.
-    commands.spawn((TransformBundle::default(), ScaleInterpolation));
+    commands.spawn((Transform::default(), ScaleInterpolation));
     
     // Interpolate translation and rotation, but not scale.
     commands.spawn((
-        TransformBundle::default(),
+        Transform::default(),
         TranslationInterpolation,
         RotationInterpolation,
     ));
@@ -101,7 +101,7 @@ fn setup(mut commands: Commands) {
     // Interpolate the entire transform: translation, rotation, and scale.
     // The components can be added individually, or using the `TransformInterpolation` component.
     commands.spawn((
-        TransformBundle::default(),
+        Transform::default(),
         TransformInterpolation,
     ));
 }
@@ -112,7 +112,7 @@ by configuring the `TransformInterpolationPlugin`:
 
 ```rust
 use bevy::prelude::*;
-use bevy_transform_interpolation::*;
+use bevy_transform_interpolation::prelude::*;
 
 fn main() {
     App::new()
@@ -164,17 +164,6 @@ since the last easing run but *outside* of the fixed timestep schedules, the eas
 Note that the core easing logic and components are intentionally not tied to interpolation directly.
 A physics engine could implement **transform extrapolation** using velocity and the same easing functionality,
 supplying its own `TranslationExtrapolation` and `RotationExtrapolation` components.
-
-## Caveats
-
-- In cases where the previous or current gameplay transform are already stored separately from `Transform`,
-  storing them in the easing states as well may be redundant. Although it *is* still useful for allowing
-  `Transform` to be modified directly and for wider compatibility with the ecosystem.
-- Transform extrapolation is currently not supported as a built-in feature, as it typically requires a velocity
-  for the prediction of the next state. However, it could be supported by external libraries such as physics engines
-  in a similar way to `src/interpolation.rs`, and simply updating the `start` and `end` states differently.
-- Large angular velocities may cause visual artifacts, as the interpolation follows the shortest path.
-  A physics engine could handle this properly.
 
 ## License
 

--- a/examples/extrapolation.rs
+++ b/examples/extrapolation.rs
@@ -1,0 +1,316 @@
+//! This example showcases how `Transform` extrapolation can be used to make movement
+//! appear smooth at fixed timesteps, and how it compares to `Transform` interpolation.
+//!
+//! Unlike `Transform` interpolation, which eases between the previous and current positions,
+//! `Transform` extrapolation predicts future positions based on velocity. This makes movement
+//! feel more responsive than interpolation, but it also produces jumpy results when the prediction is wrong,
+//! such as when the velocity of an object suddenly changes.
+
+use bevy::{
+    color::palettes::{
+        css::WHITE,
+        tailwind::{CYAN_400, LIME_400, RED_400},
+    },
+    prelude::*,
+};
+use bevy_transform_interpolation::{
+    prelude::*, RotationEasingState, TransformEasingSet, TranslationEasingState,
+};
+
+const MOVEMENT_SPEED: f32 = 250.0;
+const ROTATION_SPEED: f32 = 2.0;
+
+fn main() {
+    let mut app = App::new();
+
+    // Add the `TransformInterpolationPlugin` and `TransformExtrapolationPlugin` to the app to enable
+    // transform interpolation and extrapolation.
+    app.add_plugins((
+        DefaultPlugins,
+        TransformInterpolationPlugin::default(),
+        // This is a custom plugin! See the implementation below.
+        TransformExtrapolationPlugin,
+    ));
+
+    // Set the fixed timestep to just 5 Hz for demonstration purposes.
+    app.insert_resource(Time::<Fixed>::from_hz(5.0));
+
+    // Setup the scene and UI, and update text in `Update`.
+    app.add_systems(Startup, (setup, setup_text))
+        .add_systems(Update, (change_timestep, update_timestep_text));
+
+    // Move entities in `FixedUpdate`. The movement should appear smooth for interpolated/extrapolated entities.
+    app.add_systems(
+        FixedUpdate,
+        (flip_movement_direction.before(movement), movement, rotate),
+    );
+
+    // Run the app.
+    app.run();
+}
+
+/// The linear velocity of an entity indicating its movement speed and direction.
+#[derive(Component, Deref, DerefMut)]
+struct LinearVelocity(Vec2);
+
+/// The angular velocity of an entity indicating its rotation speed.
+#[derive(Component, Deref, DerefMut)]
+struct AngularVelocity(f32);
+
+#[derive(Debug, Default)]
+pub struct TransformExtrapolationPlugin;
+
+impl Plugin for TransformExtrapolationPlugin {
+    fn build(&self, app: &mut App) {
+        // Reset the transform to the start of the extrapolation at the beginning of the fixed timestep
+        // to match the true position from the end of the previous fixed tick.
+        app.add_systems(
+            FixedFirst,
+            reset_extrapolation.before(TransformEasingSet::Reset),
+        );
+
+        // Update the start and end state of the extrapolation at the end of the fixed timestep.
+        app.add_systems(
+            FixedLast,
+            update_easing_states.in_set(TransformEasingSet::UpdateEnd),
+        );
+    }
+
+    fn finish(&self, app: &mut App) {
+        // Add the `TransformEasingPlugin` if it hasn't been added yet.
+        // It performs the actual easing based on the start and end states set by the extrapolation.
+        if !app.is_plugin_added::<TransformEasingPlugin>() {
+            app.add_plugins(TransformEasingPlugin);
+        }
+    }
+}
+
+/// Enables `Transform` extrapolation for an entity.
+///
+/// Only extrapolates the translation and rotation components of the transform
+/// based on the `LinearVelocity` and `AngularVelocity` components.
+#[derive(Component)]
+#[require(TranslationEasingState, RotationEasingState)]
+struct TransformExtrapolation;
+
+/// Resets the transform to the start of the extrapolation at the beginning of the fixed timestep
+/// to match the true position from the end of the previous fixed tick.
+fn reset_extrapolation(
+    mut query: Query<
+        (
+            &mut Transform,
+            &TranslationEasingState,
+            &RotationEasingState,
+        ),
+        With<TransformExtrapolation>,
+    >,
+) {
+    for (mut transform, translation_easing, rotation_easing) in &mut query {
+        if let Some(start) = translation_easing.start {
+            transform.translation = start;
+        }
+        if let Some(start) = rotation_easing.start {
+            transform.rotation = start;
+        }
+    }
+}
+
+/// Updates the start and end states of the extrapolation for the next fixed timestep.
+fn update_easing_states(
+    mut query: Query<
+        (
+            &Transform,
+            &mut TranslationEasingState,
+            &mut RotationEasingState,
+            &LinearVelocity,
+            &AngularVelocity,
+        ),
+        With<TransformExtrapolation>,
+    >,
+    time: Res<Time>,
+) {
+    let delta_secs = time.delta_secs();
+
+    for (transform, mut translation_easing, mut rotation_easing, lin_vel, ang_vel) in &mut query {
+        translation_easing.start = Some(transform.translation);
+        rotation_easing.start = Some(transform.rotation);
+
+        // Extrapolate the next state based on the current state and velocities.
+        let next_translation = transform.translation + lin_vel.extend(0.0) * delta_secs;
+        let next_rotation = transform.rotation * Quat::from_rotation_z(ang_vel.0 * delta_secs);
+
+        // In 3D, with a `Vec3` angular velocity, the next rotation could be computed like this:
+        //
+        // let scaled_axis = ang_vel.0 * delta_secs;
+        // let next_rotation = transform.rotation * Quat::from_scaled_axis(scaled_axis);
+
+        translation_easing.end = Some(next_translation);
+        rotation_easing.end = Some(next_rotation);
+    }
+}
+
+// The rest of the code is scene setup, and largely the same as in the `interpolation.rs` example.
+
+fn setup(
+    mut commands: Commands,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    // Spawn a camera.
+    commands.spawn(Camera2d);
+
+    let mesh = meshes.add(Rectangle::from_length(60.0));
+
+    // This entity uses transform interpolation.
+    commands.spawn((
+        Name::new("Interpolation"),
+        Mesh2d(mesh.clone()),
+        MeshMaterial2d(materials.add(Color::from(CYAN_400)).clone()),
+        Transform::from_xyz(-500.0, 120.0, 0.0),
+        TransformInterpolation,
+        LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
+        AngularVelocity(ROTATION_SPEED),
+    ));
+
+    // This entity uses transform extrapolation.
+    commands.spawn((
+        Name::new("Extrapolation"),
+        Mesh2d(mesh.clone()),
+        MeshMaterial2d(materials.add(Color::from(LIME_400)).clone()),
+        Transform::from_xyz(-500.0, 00.0, 0.0),
+        TransformExtrapolation,
+        LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
+        AngularVelocity(ROTATION_SPEED),
+    ));
+
+    // This entity is simulated in `FixedUpdate` without any smoothing.
+    commands.spawn((
+        Name::new("No Interpolation"),
+        Mesh2d(mesh.clone()),
+        MeshMaterial2d(materials.add(Color::from(RED_400)).clone()),
+        Transform::from_xyz(-500.0, -120.0, 0.0),
+        LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
+        AngularVelocity(ROTATION_SPEED),
+    ));
+}
+
+/// Flips the movement directions of objects when they reach the left or right side of the screen.
+fn flip_movement_direction(mut query: Query<(&Transform, &mut LinearVelocity)>) {
+    for (transform, mut lin_vel) in &mut query {
+        if transform.translation.x > 500.0 && lin_vel.0.x > 0.0 {
+            lin_vel.0 = Vec2::new(-MOVEMENT_SPEED, 0.0);
+        } else if transform.translation.x < -500.0 && lin_vel.0.x < 0.0 {
+            lin_vel.0 = Vec2::new(MOVEMENT_SPEED, 0.0);
+        }
+    }
+}
+
+/// Changes the timestep of the simulation when the up or down arrow keys are pressed.
+fn change_timestep(mut time: ResMut<Time<Fixed>>, keyboard_input: Res<ButtonInput<KeyCode>>) {
+    if keyboard_input.pressed(KeyCode::ArrowUp) {
+        let new_timestep = (time.delta_secs_f64() * 0.9).max(1.0 / 255.0);
+        time.set_timestep_seconds(new_timestep);
+    }
+    if keyboard_input.pressed(KeyCode::ArrowDown) {
+        let new_timestep = (time.delta_secs_f64() * 1.1).min(1.0);
+        time.set_timestep_seconds(new_timestep);
+    }
+}
+
+/// Moves entities based on their `LinearVelocity`.
+fn movement(mut query: Query<(&mut Transform, &LinearVelocity)>, time: Res<Time>) {
+    let delta_secs = time.delta_secs();
+
+    for (mut transform, lin_vel) in &mut query {
+        transform.translation += lin_vel.extend(0.0) * delta_secs;
+    }
+}
+
+/// Rotates entities based on their `AngularVelocity`.
+fn rotate(mut query: Query<(&mut Transform, &AngularVelocity)>, time: Res<Time>) {
+    let delta_secs = time.delta_secs();
+
+    for (mut transform, ang_vel) in &mut query {
+        transform.rotate_local_z(ang_vel.0 * delta_secs);
+    }
+}
+
+#[derive(Component)]
+struct TimestepText;
+
+fn setup_text(mut commands: Commands) {
+    let font = TextFont {
+        font_size: 20.0,
+        ..default()
+    };
+
+    commands
+        .spawn((
+            Text::new("Fixed Hz: "),
+            TextColor::from(WHITE),
+            font.clone(),
+            Node {
+                position_type: PositionType::Absolute,
+                top: Val::Px(10.0),
+                left: Val::Px(10.0),
+                ..default()
+            },
+        ))
+        .with_child((TimestepText, TextSpan::default()));
+
+    commands.spawn((
+        Text::new("Change Timestep With Up/Down Arrow"),
+        TextColor::from(WHITE),
+        font.clone(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(10.0),
+            right: Val::Px(10.0),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
+        Text::new("Interpolation"),
+        TextColor::from(CYAN_400),
+        font.clone(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(50.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
+        Text::new("Extrapolation"),
+        TextColor::from(LIME_400),
+        font.clone(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(75.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
+        Text::new("No Interpolation"),
+        TextColor::from(RED_400),
+        font.clone(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(100.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+    ));
+}
+
+fn update_timestep_text(
+    mut text: Single<&mut TextSpan, With<TimestepText>>,
+    time: Res<Time<Fixed>>,
+) {
+    let timestep = time.timestep().as_secs_f32().recip();
+    text.0 = format!("{timestep:.2}");
+}

--- a/examples/extrapolation.rs
+++ b/examples/extrapolation.rs
@@ -1,3 +1,6 @@
+//! Transform extrapolation is not a built-in feature in `bevy_transform_interpolation`, because it requires velocity.
+//! However, it can be implemented in a relatively straightforward way on top of `TransformEasingPlugin`.
+//!
 //! This example showcases how `Transform` extrapolation can be used to make movement
 //! appear smooth at fixed timesteps, and how it compares to `Transform` interpolation.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@
 //! ## Features
 //!
 //! - Interpolate changes made to translation, rotation, and scale in [`FixedUpdate`].
-//! - Interpolate individual [`Transform`] properties to prevent unnecessary computation.
+//! - Interpolate individual [`Transform`] properties to reduce unnecessary computation.
 //! - Apply interpolation to individual entities or to all entities.
-//! - Custom easing backends, making it straightforward to implement things like transform extrapolation.
+//! - Works out of the box with physics engines using fixed timesteps.
+//! - Extensible with custom easing backends.
 //!
 //! ## Getting Started
 //!
@@ -20,7 +21,7 @@
 //!
 //! To enable [`Transform`] interpolation, add the [`TransformInterpolationPlugin`] to your app:
 //!
-//! ```rust,no_run
+//! ```no_run
 //! use bevy::prelude::*;
 //! use bevy_transform_interpolation::prelude::*;
 //!
@@ -89,7 +90,7 @@
 //! Internally, `bevy_transform_interpolation` simply maintains components that store the `start` and `end` of the interpolation.
 //! For example, translation uses the following component for easing the movement:
 //!
-//! ```rust
+//! ```
 //! # use bevy::prelude::*;
 //! #
 //! pub struct TranslationEasingState {
@@ -111,15 +112,6 @@
 //! Note that the core easing logic and components are intentionally not tied to interpolation directly.
 //! A physics engine could implement **transform extrapolation** using velocity and the same easing functionality,
 //! supplying its own `TranslationExtrapolation` and `RotationExtrapolation` components.
-//!
-//! ## Caveats
-//!
-//! - In cases where the previous or current gameplay transform are already stored separately from [`Transform`],
-//!   storing them in the easing states as well may be redundant. Although it *is* still useful for allowing
-//!   [`Transform`] to be modified directly and for wider compatibility with the ecosystem.
-//! - Transform extrapolation is currently not supported as a built-in feature, as it typically requires a velocity
-//!   for the prediction of the next state. However, it could be supported by external libraries such as physics engines
-//!   in a similar way to `src/interpolation.rs`, and simply updating the `start` and `end` states differently.
 
 #![allow(clippy::needless_doctest_main)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,69 +2,27 @@
 //!
 //! A general-purpose [`Transform`] interpolation plugin for fixed timesteps for the [Bevy game engine](https://bevyengine.org).
 //!
-//! ## What Is This For?
+//! ## Features
 //!
-//! A lot of gameplay logic and movement systems typically use a fixed timestep to produce consistent and stable behavior
-//! regardless of the frame rate. Notable examples include physics simulation and character movement.
+//! - Interpolate changes made to translation, rotation, and scale in [`FixedUpdate`].
+//! - Interpolate individual [`Transform`] properties to prevent unnecessary computation.
+//! - Apply interpolation to individual entities or to all entities.
+//! - Custom easing backends, making it straightforward to implement things like transform extrapolation.
 //!
-//! However, this can make movement appear choppy, especially on displays with a high refresh rate.
-//! To achieve visually smooth movement while using a fixed timestep, the visual transform must be smoothed
-//! independently of the "true" gameplay transform.
+//! ## Getting Started
 //!
-//! The most common way to do this is to use **transform interpolation**, which interpolates movement from the previous
-//! state to the current state. This could be done by storing the current and old gameplay positions in their own components
-//! and interpolating [`Transform`] using them:
-//!
-//! ```rust
-//! use bevy::prelude::*;
-//!
-//! #[derive(Component, Deref, DerefMut)]
-//! struct Position(Vec3);
-//!
-//! #[derive(Component, Deref, DerefMut)]
-//! struct OldPosition(Vec3);
-//!
-//! // Runs in `Update` or `PostUpdate`.
-//! fn interpolate_transforms(
-//!     mut query: Query<(&mut Transform, &Position, &OldPosition)>,
-//!     fixed_time: Res<Time<Fixed>>
-//! ) {
-//!     // How much of a "partial timestep" has accumulated since the last fixed timestep run.
-//!     // Between `0.0` and `1.0`.
-//!     let overstep_fraction = fixed_time.overstep_fraction();
-//!
-//!     for (mut transform, position, old_position) in &mut query {
-//!         // Linearly interpolate the translation from the old position to the current one.
-//!         transform.translation = old_position.lerp(position.0, overstep_fraction);
-//!     }
-//! }
-//! ```
-//!
-//! In fact, you could simply plug the above implementation into your own application if you wanted to!
-//!
-//! However, it requires you to use `Position` for gameplay logic, and to manage `OldPosition` somewhere.
-//! This can be annoying, and is incompatibile with third party libraries that expect to be able to modify
-//! the transform directly.
-//!
-//! `bevy_transform_interpolation` aims to be a drop-in solution that allows easy and efficient transform interpolation,
-//! while still allowing the usage of [`Transform`] for gameplay logic. It should be automatically compatible with physics engines
-//! such as [Avian](https://github.com/Jondolf/avian) and [`bevy_rapier`](https://github.com/dimforge/bevy_rapier), as long as
-//! the simulation is run in [`FixedUpdate`] or [`FixedPostUpdate`].
-//!
-//! ## Usage
-//!
-//! First, add `bevy_transform_interpolation` to your dependencies in `Cargo.toml`:
+//! First, add `bevy_transform_interpolation` as a dependency in your `Cargo.toml`:
 //!
 //! ```toml
 //! [dependencies]
 //! bevy_transform_interpolation = { git = "https://github.com/Jondolf/bevy_transform_interpolation" }
 //! ```
 //!
-//! Next, add the [`TransformInterpolationPlugin`]:
+//! To enable [`Transform`] interpolation, add the [`TransformInterpolationPlugin`] to your app:
 //!
 //! ```rust,no_run
 //! use bevy::prelude::*;
-//! use bevy_transform_interpolation::*;
+//! use bevy_transform_interpolation::prelude::*;
 //!
 //! fn main() {
 //!     App::new()
@@ -74,70 +32,57 @@
 //! }
 //! ```
 //!
-//! Transform interpolation can be enabled very granularly in `bevy_transform_interpolation`.
-//! You can choose to interpolate transform, rotation, or scale individually, or use any combination of them:
+//! By default, interpolation is only performed for entities with the [`TransformInterpolation`] component:
 //!
-//! ```rust
+//! ```
 //! use bevy::prelude::*;
-//! use bevy_transform_interpolation::*;
+//! use bevy_transform_interpolation::prelude::*;
 //!
 //! fn setup(mut commands: Commands) {
-//!     // Only interpolate translation.
-//!     commands.spawn((TransformBundle::default(), TranslationInterpolation));
-//!     
-//!     // Only interpolate rotation.
-//!     commands.spawn((TransformBundle::default(), RotationInterpolation));
-//!     
-//!     // Only interpolate scale.
-//!     commands.spawn((TransformBundle::default(), ScaleInterpolation));
-//!     
-//!     // Interpolate translation and rotation, but not scale.
-//!     commands.spawn((
-//!         TransformBundle::default(),
-//!         TranslationInterpolation,
-//!         RotationInterpolation,
-//!     ));
-//!     
 //!     // Interpolate the entire transform: translation, rotation, and scale.
-//!     // The components can be added individually, or using the `TransformInterpolationBundle`.
 //!     commands.spawn((
-//!         TransformBundle::default(),
-//!         TransformInterpolationBundle::default(),
+//!         Transform::default(),
+//!         TransformInterpolation,
 //!     ));
 //! }
 //! ```
 //!
-//! You can also enable transform interpolation globally for *all* entities that have a [`Transform`]
-//! by configuring the [`TransformInterpolationPlugin`]:
+//! Now, any changes made to the [`Transform`] of the entity in [`FixedPreUpdate`], [`FixedUpdate`], or [`FixedPostUpdate`]
+//! will automatically be interpolated in between fixed timesteps.
 //!
-//! ```rust,no_run
+//! If you want *all* entities with a [`Transform`] to be interpolated by default, you can use
+//! [`TransformInterpolationPlugin::interpolate_all()`]:
+//!
+//! ```
 //! use bevy::prelude::*;
-//! use bevy_transform_interpolation::*;
+//! use bevy_transform_interpolation::prelude::*;
 //!
 //! fn main() {
-//!     App::new()
-//!         .add_plugins((
-//!             DefaultPlugins,
-//!             // Interpolate translation and rotation, but not scale.
-//!             TransformInterpolationPlugin {
-//!                 global_translation_interpolation: true,
-//!                 global_rotation_interpolation: true,
-//!                 global_scale_interpolation: false,
-//!             },
-//!         ))
-//!         // ...other plugins, resources, and systems
-//!         .run();
+//!    App::build()
+//!       .add_plugins(TransformInterpolationPlugin::interpolate_all())
+//!       // ...
+//!       .run();
 //! }
 //! ```
 //!
-//! If interpolation is enabled globally, it can still be disabled for individual entities using the [`NoTranslationInterpolation`],
-//! [`NoRotationInterpolation`], and [`NoScaleInterpolation`] components.
+//! It is also possible to opt out of interpolation for individual entities, or even interpolate
+//! specific [`Transform`] properties granularly. See the documentation of the [`TransformInterpolationPlugin`]
+//! for more information.
 //!
-//! Now, any changes made to [`Transform`] in [`FixedPreUpdate`], [`FixedUpdate`], or [`FixedPostUpdate`] will automatically
-//! be smoothed in between the fixed timesteps for entities that have transform interpolation enabled.
+//! ## Custom Easing Backends
 //!
-//! Changing [`Transform`] manually in any schedule that *doesn't* use a fixed timestep is also supported,
-//! but it is equivalent to teleporting, and disables interpolation for the entity for the remainder of that fixed timestep.
+//! Transforms are interpolated using easing functions, which are applied to the `start` and `end`
+//! of the [`TranslationEasingState`], [`RotationEasingState`], and [`ScaleEasingState`] components.
+//! These components are added and managed automatically for entities with the [`TransformInterpolation`] component.
+//!
+//! In the earlier example, the [`TransformInterpolationPlugin`] was used to enable interpolation.
+//! However, the core easing logic and state management are actually handled by the automatically
+//! added [`TransformEasingPlugin`]. The [`TransformInterpolationPlugin`] only updates the `start`
+//! and `end` states of the easing.
+//!
+//! It is possible to replace interpolation with another approach, such as a `TransformExtrapolationPlugin`,
+//! while reusing the core easing logic of the [`TransformEasingPlugin`]. An example of this can be found in
+//! `examples/extrapolation.rs`.
 //!
 //! ## How Does It Work?
 //!
@@ -178,68 +123,61 @@
 
 #![allow(clippy::needless_doctest_main)]
 
-mod interpolation;
+pub mod interpolation;
+
+/// The prelude.
+///
+/// This includes the most common types in this crate, re-exported for your convenience.
+pub mod prelude {
+    #[doc(hidden)]
+    pub use crate::interpolation::*;
+    #[doc(hidden)]
+    pub use crate::TransformEasingPlugin;
+}
+
+// For doc links.
+#[allow(unused_imports)]
+use interpolation::*;
 
 use bevy::{
     ecs::{component::Tick, system::SystemChangeTick},
     prelude::*,
 };
-pub use interpolation::*;
 
-/// Performs transform interpolation.
-#[derive(Debug, Default)]
-pub struct TransformInterpolationPlugin {
-    /// If `true`, translation will be interpolated for all entities with the [`Transform`] component by default.
-    ///
-    /// This can be overridden for individual entities by adding the [`NoTranslationInterpolation`] component.
-    pub global_translation_interpolation: bool,
-    /// If `true`, rotation will be interpolated for all entities with the [`Transform`] component by default.
-    ///
-    /// This can be overridden for individual entities by adding the [`NoRotationInterpolation`] component.
-    pub global_rotation_interpolation: bool,
-    /// If `true`, scale will be interpolated for all entities with the [`Transform`] component by default.
-    ///
-    /// This can be overridden for individual entities by adding the [`NoScaleInterpolation`] component.
-    pub global_scale_interpolation: bool,
-}
+/// A plugin for applying easing to [`Transform`] changes, making movement in [`FixedUpdate`] appear smooth.
+///
+/// On its own, this plugin does *not* perform any automatic interpolation. It only performs easing
+/// between the `start` and `end` states of the [`TranslationEasingState`], [`RotationEasingState`], and [`ScaleEasingState`]
+/// components, and is responsible for resetting them at appropriate times.
+///
+/// To actually perform automatic easing, an easing backend that updates the `start` and `end` states must be used.
+/// The [`TransformInterpolationPlugin`] is provided for transform interpolation, but custom backends can also be implemented.
+pub struct TransformEasingPlugin;
 
-impl TransformInterpolationPlugin {
-    /// Enables interpolation for translation, rotation, and scale for all entities with the [`Transform`] component.
-    ///
-    /// This can be overridden for individual entities by adding the [`NoTranslationInterpolation`], [`NoRotationInterpolation`],
-    /// and [`NoScaleInterpolation`] components.
-    pub const fn interpolate_all() -> Self {
-        Self {
-            global_translation_interpolation: true,
-            global_rotation_interpolation: true,
-            global_scale_interpolation: true,
-        }
-    }
-}
-
-impl Plugin for TransformInterpolationPlugin {
+impl Plugin for TransformEasingPlugin {
     fn build(&self, app: &mut App) {
+        // Register easing components.
         app.register_type::<(
             TranslationEasingState,
             RotationEasingState,
             ScaleEasingState,
         )>();
-        app.register_type::<(
-            TranslationInterpolation,
-            RotationInterpolation,
-            ScaleInterpolation,
-        )>();
-        app.register_type::<(
-            NoTranslationInterpolation,
-            NoRotationInterpolation,
-            NoScaleInterpolation,
-        )>();
 
         app.init_resource::<LastEasingTick>();
 
+        // Reset easing states and update start values at the start of the fixed timestep.
+        app.configure_sets(
+            FixedFirst,
+            (TransformEasingSet::Reset, TransformEasingSet::UpdateStart).chain(),
+        );
+
+        // Update end values at the end of the fixed timestep.
+        app.configure_sets(FixedLast, TransformEasingSet::UpdateEnd);
+
+        // Perform transform easing in `PostUpdate`, before transform propagation.
         app.configure_sets(
             PostUpdate,
-            TransformEasingSet.before(TransformSystem::TransformPropagate),
+            TransformEasingSet::Ease.before(TransformSystem::TransformPropagate),
         );
 
         app.add_systems(
@@ -247,26 +185,13 @@ impl Plugin for TransformInterpolationPlugin {
             (
                 reset_easing_states_on_transform_change,
                 (
-                    reset_translation_interpolation,
-                    reset_rotation_interpolation,
-                    reset_scale_interpolation,
-                ),
-                (
-                    update_translation_interpolation_start,
-                    update_rotation_interpolation_start,
-                    update_scale_interpolation_start,
+                    reset_translation_easing,
+                    reset_rotation_easing,
+                    reset_scale_easing,
                 ),
             )
-                .chain(),
-        );
-        app.add_systems(
-            FixedLast,
-            (
-                update_translation_interpolation_end,
-                update_rotation_interpolation_end,
-                update_scale_interpolation_end,
-            )
-                .chain(),
+                .chain()
+                .in_set(TransformEasingSet::Reset),
         );
 
         app.add_systems(
@@ -277,36 +202,24 @@ impl Plugin for TransformInterpolationPlugin {
                 update_last_easing_tick,
             )
                 .chain()
-                .in_set(TransformEasingSet),
-        );
-
-        let interpolate_translation = self.global_translation_interpolation;
-        let interpolate_rotation = self.global_rotation_interpolation;
-        let interpolate_scale = self.global_scale_interpolation;
-
-        app.add_observer(
-            move |trigger: Trigger<OnAdd, Transform>, mut commands: Commands| {
-                if interpolate_translation {
-                    commands
-                        .entity(trigger.entity())
-                        .insert(TranslationInterpolation);
-                }
-                if interpolate_rotation {
-                    commands
-                        .entity(trigger.entity())
-                        .insert(RotationInterpolation);
-                }
-                if interpolate_scale {
-                    commands.entity(trigger.entity()).insert(ScaleInterpolation);
-                }
-            },
+                .in_set(TransformEasingSet::Ease),
         );
     }
 }
 
-/// A system set for transform interpolation. Runs in [`PostUpdate`], before [`TransformSystem::TransformPropagate`].
+/// A system set for easing transform.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct TransformEasingSet;
+pub enum TransformEasingSet {
+    /// Resets easing states to `None` at the start of the fixed timestep.
+    Reset,
+    /// Updates the `start` values for easing at the start of the fixed timestep.
+    UpdateStart,
+    /// Updates the `end` values for easing at the end of the fixed timestep.
+    UpdateEnd,
+    /// Eases the transform values in between the `start` and `end` states.
+    /// Runs in [`PostUpdate`], before [`TransformSystem::TransformPropagate`].
+    Ease,
+}
 
 /// A resource that stores the last tick when easing was performed.
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut)]
@@ -315,8 +228,8 @@ struct LastEasingTick(Tick);
 /// Stores the start and end states used for interpolating the translation of an entity.
 /// The change in translation is smoothed from `start` to `end` in between [`FixedUpdate`] runs.
 ///
-/// On its own, this component is not updated automatically. To perform automatic interpolation,
-/// add the [`TranslationInterpolation`] component.
+/// On its own, this component is not updated automatically. Enable an easing backend
+/// such as the [`TransformInterpolationPlugin`] to perform automatic interpolation.
 #[derive(Component, Clone, Copy, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default)]
 pub struct TranslationEasingState {
@@ -327,8 +240,8 @@ pub struct TranslationEasingState {
 /// Stores the start and end states used for interpolating the rotation of an entity.
 /// The change in rotation is smoothed from `start` to `end` in between [`FixedUpdate`] runs.
 ///
-/// On its own, this component is not updated automatically. To perform automatic interpolation,
-/// add the [`RotationInterpolation`] component.
+/// On its own, this component is not updated automatically. Enable an easing backend
+/// such as the [`TransformInterpolationPlugin`] to perform automatic interpolation.
 #[derive(Component, Clone, Copy, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default)]
 pub struct RotationEasingState {
@@ -339,8 +252,8 @@ pub struct RotationEasingState {
 /// Stores the start and end states used for interpolating the scale of an entity.
 /// The change in scale is smoothed from `start` to `end` in between [`FixedUpdate`] runs.
 ///
-/// On its own, this component is not updated automatically. To perform automatic interpolation,
-/// add the [`ScaleInterpolation`] component.
+/// On its own, this component is not updated automatically. Enable an easing backend
+/// such as the [`TransformInterpolationPlugin`] to perform automatic interpolation.
 #[derive(Component, Clone, Copy, Debug, Default, PartialEq, Reflect)]
 #[reflect(Component, Debug, Default)]
 pub struct ScaleEasingState {
@@ -356,7 +269,7 @@ fn update_last_easing_tick(
 }
 
 /// Resets the easing states to `None` when [`Transform`] is modified outside of the fixed timestep schedules
-/// or interpolation logic.
+/// or interpolation logic. This makes it possible to "teleport" entities in schedules like [`Update`].
 #[allow(clippy::type_complexity)]
 fn reset_easing_states_on_transform_change(
     mut query: Query<
@@ -412,9 +325,7 @@ fn reset_easing_states_on_transform_change(
 }
 
 /// Resets the `start` and `end` states for translation interpolation.
-fn reset_translation_interpolation(
-    mut query: Query<(&mut Transform, &mut TranslationEasingState)>,
-) {
+fn reset_translation_easing(mut query: Query<(&mut Transform, &mut TranslationEasingState)>) {
     for (mut transform, mut easing) in &mut query {
         // Make sure the previous easing is fully applied.
         if let Some(end) = easing.end {
@@ -427,7 +338,7 @@ fn reset_translation_interpolation(
 }
 
 /// Resets the `start` and `end` states for rotation interpolation.
-fn reset_rotation_interpolation(mut query: Query<(&mut Transform, &mut RotationEasingState)>) {
+fn reset_rotation_easing(mut query: Query<(&mut Transform, &mut RotationEasingState)>) {
     for (mut transform, mut easing) in &mut query {
         // Make sure the previous easing is fully applied.
         if let Some(end) = easing.end {
@@ -440,7 +351,7 @@ fn reset_rotation_interpolation(mut query: Query<(&mut Transform, &mut RotationE
 }
 
 /// Resets the `start` and `end` states for scale interpolation.
-fn reset_scale_interpolation(mut query: Query<(&mut Transform, &mut ScaleEasingState)>) {
+fn reset_scale_easing(mut query: Query<(&mut Transform, &mut ScaleEasingState)>) {
     for (mut transform, mut easing) in &mut query {
         // Make sure the previous easing is fully applied.
         if let Some(end) = easing.end {
@@ -452,7 +363,7 @@ fn reset_scale_interpolation(mut query: Query<(&mut Transform, &mut ScaleEasingS
     }
 }
 
-/// Interpolates the translations of entities.
+/// Eases the translations of entities.
 fn ease_translation(
     mut query: Query<(&mut Transform, &TranslationEasingState)>,
     time: Res<Time<Fixed>>,
@@ -466,7 +377,7 @@ fn ease_translation(
     });
 }
 
-/// Interpolates the rotations of entities.
+/// Eases the rotations of entities.
 fn ease_rotation(mut query: Query<(&mut Transform, &RotationEasingState)>, time: Res<Time<Fixed>>) {
     let overstep = time.overstep_fraction();
 
@@ -479,7 +390,7 @@ fn ease_rotation(mut query: Query<(&mut Transform, &RotationEasingState)>, time:
         });
 }
 
-/// Interpolates the scales of entities.
+/// Eases the scales of entities.
 fn ease_scale(mut query: Query<(&mut Transform, &ScaleEasingState)>, time: Res<Time<Fixed>>) {
     let overstep = time.overstep_fraction();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ impl Plugin for TransformEasingPlugin {
         // Perform easing.
         app.add_systems(
             PostUpdate,
-            (ease_translation_lerp, ease_rotation_slerp, ease_scale)
+            (ease_translation_lerp, ease_rotation_slerp, ease_scale_lerp)
                 .in_set(TransformEasingSet::Ease),
         );
 
@@ -404,7 +404,7 @@ fn ease_rotation_slerp(
 }
 
 /// Eases the scales of entities with linear interpolation.
-fn ease_scale(mut query: Query<(&mut Transform, &ScaleEasingState)>, time: Res<Time<Fixed>>) {
+fn ease_scale_lerp(mut query: Query<(&mut Transform, &ScaleEasingState)>, time: Res<Time<Fixed>>) {
     let overstep = time.overstep_fraction();
 
     query.iter_mut().for_each(|(mut transform, interpolation)| {


### PR DESCRIPTION
- Extract general easing logic from `TransformInterpolationPlugin` into new `TransformEasingPlugin`
- Add more system sets to `TransformEasingSet` and improve scheduling
- Rename easing systems to include `_lerp`/`_slerp`
- Significantly improve docs for interpolation and components
- Rework crate-level docs
- Impove `interpolation` example
- Add `extrapolation` example