### PR TITLE
Add built-in transform extrapolation and Hermite interpolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,14 @@ categories = ["game-development"]
 bevy = { version = "0.15", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.15" }
+bevy = { version = "0.15", default-features = false, features = [
+    "bevy_core_pipeline",
+    "bevy_text",
+    "bevy_ui",
+    "bevy_asset",
+    "bevy_render",
+    "bevy_sprite",
+    "default_font",
+    "bevy_winit",
+    "bevy_window",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,7 @@ keywords = ["gamedev", "easing", "bevy"]
 categories = ["game-development"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc", default-features = false, features = [
-    "bevy_asset",
-    "bevy_render",
-    "bevy_text",
-    "bevy_ui",
-    "bevy_winit",
-    "default_font",
-] }
+bevy = { git = "https://github.com/bevyengine/bevy" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["gamedev", "easing", "bevy"]
 categories = ["game-development"]
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
+bevy = { version = "0.15", default-features = false }
 
 [dev-dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy" }
+bevy = { version = "0.15" }

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ fn main() {
 }
 ```
 
-If interpolation is enabled globally, it can still be disabled for individual entities using the `NoTranslationInterpolation`,
-`NoRotationInterpolation`, and `NoScaleInterpolation` components.
+If interpolation is enabled globally, it can still be disabled for individual entities using the `NoTranslationEasing`,
+`NoRotationEasing`, and `NoScaleEasing` components.
 
 Now, any changes made to `Transform` in `FixedPreUpdate`, `FixedUpdate`, or `FixedPostUpdate` will automatically
 be smoothed in between the fixed timesteps for entities that have transform interpolation enabled.

--- a/examples/hermite_interpolation.rs
+++ b/examples/hermite_interpolation.rs
@@ -18,7 +18,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_transform_interpolation::{
-    hermite::{RotationHermite, TransformHermitePlugin, TranslationHermite},
+    hermite::{RotationHermiteEasing, TransformHermiteEasingPlugin, TranslationHermiteEasing},
     prelude::*,
     VelocitySource,
 };
@@ -30,18 +30,18 @@ fn main() {
     let mut app = App::new();
 
     // Add the `TransformInterpolationPlugin` to the app to enable transform interpolation.
-    // Add the `TransformHermitePlugin` to the app to enable Hermite interpolation for easing.
+    // Add the `TransformHermiteEasingPlugin` to the app to enable Hermite interpolation for easing.
     app.add_plugins((
         DefaultPlugins,
         TransformInterpolationPlugin::default(),
         // We must specify "velocity sources" to tell the plugin how to extract velocity information.
         // These are implemented below this function.
-        TransformHermitePlugin::<LinVelSource, AngVelSource>::default(),
+        TransformHermiteEasingPlugin::<LinVelSource, AngVelSource>::default(),
     ));
 
     // Optional: Make the previous velocity components required for Hermite interpolation to insert them automatically.
-    app.register_required_components::<TranslationHermite, PreviousLinearVelocity>();
-    app.register_required_components::<RotationHermite, PreviousAngularVelocity>();
+    app.register_required_components::<TranslationHermiteEasing, PreviousLinearVelocity>();
+    app.register_required_components::<RotationHermiteEasing, PreviousAngularVelocity>();
 
     // Set the fixed timestep to just 5 Hz for demonstration purposes.
     app.insert_resource(Time::<Fixed>::from_hz(5.0));
@@ -153,10 +153,10 @@ fn setup(
         Mesh2d(mesh.clone()),
         MeshMaterial2d(materials.add(Color::from(LIME_400)).clone()),
         Transform::from_xyz(-500.0, 0.0, 0.0),
-        // Note: `TransformHermite` on its own does not perform interpolation.
+        // Note: `TransformHermiteEasing` on its own does not perform interpolation.
         //       Either `TransformInterpolation` or `TransformExtrapolation` must be present.
         TransformInterpolation,
-        TransformHermite,
+        TransformHermiteEasing,
         LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
         AngularVelocity(ROTATION_SPEED),
     ));

--- a/examples/hermite_interpolation.rs
+++ b/examples/hermite_interpolation.rs
@@ -1,32 +1,47 @@
-//! This example showcases how `Transform` interpolation can be used to make movement
-//! appear smooth at fixed timesteps.
+//! This example showcases how Hermite interpolation can be used to make `Transform` easing
+//! more accurate and reliable.
 //!
-//! `Transform` interpolation updates `Transform` at every frame in between
-//! fixed ticks to smooth out the visual result. The interpolation is done
-//! from the previous positions to the current positions, which keeps movement smooth,
-//! but has the downside of making movement feel slightly delayed as the rendered
-//! result lags slightly behind the true positions.
+//! By default, `Transform` interpolation and extrapolation use *linear interpolation* (`lerp`)
+//! for easing translation and scale, and *spherical linear interpolation* (`slerp`)
+//! for easing rotation. This is computationally efficient and works well for most cases.
 //!
-//! For an example of how transform extrapolation could be used instead,
-//! see `examples/extrapolation.rs`.
+//! However, for more accurate and reliable easing that works at arbitrary velocities,
+//! it may be preferable to use *Hermite interpolation*. It uses both position and velocity information
+//! to estimate the trajectories of entities, producing smoother results.
 
 use bevy::{
     color::palettes::{
         css::WHITE,
-        tailwind::{CYAN_400, RED_400},
+        tailwind::{CYAN_400, LIME_400, RED_400},
     },
+    ecs::query::QueryData,
     prelude::*,
 };
-use bevy_transform_interpolation::prelude::*;
+use bevy_transform_interpolation::{
+    hermite::{RotationHermite, TransformHermitePlugin, TranslationHermite},
+    prelude::*,
+    VelocitySource,
+};
 
 const MOVEMENT_SPEED: f32 = 250.0;
-const ROTATION_SPEED: f32 = 2.0;
+const ROTATION_SPEED: f32 = std::f32::consts::TAU * 3.0;
 
 fn main() {
     let mut app = App::new();
 
     // Add the `TransformInterpolationPlugin` to the app to enable transform interpolation.
-    app.add_plugins((DefaultPlugins, TransformInterpolationPlugin::default()));
+    // Add the `TransformHermitePlugin` to the app to enable Hermite interpolation for easing.
+    app.add_plugins((
+        DefaultPlugins,
+        TransformInterpolationPlugin::default(),
+        // We must specify "velocity sources" to tell the plugin how to extract velocity information.
+        // These are implemented below this function.
+        TransformHermitePlugin::<LinVelSource, AngVelSource>::default(),
+    ));
+
+    // Optional: Make the previous velocity components required for Hermite interpolation to insert them automatically.
+    app.register_required_components::<TranslationHermite, PreviousLinearVelocity>();
+    app.register_required_components::<RotationHermite, PreviousAngularVelocity>();
 
     // Set the fixed timestep to just 5 Hz for demonstration purposes.
     app.insert_resource(Time::<Fixed>::from_hz(5.0));
@@ -34,6 +49,9 @@ fn main() {
     // Setup the scene and UI, and update text in `Update`.
     app.add_systems(Startup, (setup, setup_text))
         .add_systems(Update, (change_timestep, update_timestep_text));
+
+    // Update the previous velocity components in `FixedPreUpdate`.
+    app.add_systems(FixedPreUpdate, update_previous_velocity);
 
     // Move entities in `FixedUpdate`. The movement should appear smooth for interpolated entities.
     app.add_systems(
@@ -46,12 +64,65 @@ fn main() {
 }
 
 /// The linear velocity of an entity indicating its movement speed and direction.
-#[derive(Component, Deref, DerefMut)]
+#[derive(Component, Default, Deref, DerefMut)]
 struct LinearVelocity(Vec2);
 
+/// The previous linear velocity of an entity indicating its movement speed and direction during the previous frame.
+#[derive(Component, Default, Deref, DerefMut)]
+struct PreviousLinearVelocity(Vec2);
+
 /// The angular velocity of an entity indicating its rotation speed.
-#[derive(Component, Deref, DerefMut)]
+#[derive(Component, Default, Deref, DerefMut)]
 struct AngularVelocity(f32);
+
+/// The previous angular velocity of an entity indicating its rotation speed during the previous frame.
+#[derive(Component, Default, Deref, DerefMut)]
+struct PreviousAngularVelocity(f32);
+
+#[derive(QueryData)]
+struct LinVelSource;
+
+impl VelocitySource for LinVelSource {
+    type Previous = PreviousLinearVelocity;
+    type Current = LinearVelocity;
+
+    fn previous(start: &Self::Previous) -> Vec3 {
+        start.0.extend(0.0)
+    }
+
+    fn current(end: &Self::Current) -> Vec3 {
+        end.0.extend(0.0)
+    }
+}
+
+#[derive(QueryData)]
+struct AngVelSource;
+
+impl VelocitySource for AngVelSource {
+    type Previous = PreviousAngularVelocity;
+    type Current = AngularVelocity;
+
+    fn previous(start: &Self::Previous) -> Vec3 {
+        Vec3::Z * start.0
+    }
+
+    fn current(end: &Self::Current) -> Vec3 {
+        Vec3::Z * end.0
+    }
+}
+
+fn update_previous_velocity(
+    mut lin_vel_query: Query<(&LinearVelocity, &mut PreviousLinearVelocity)>,
+    mut ang_vel_query: Query<(&AngularVelocity, &mut PreviousAngularVelocity)>,
+) {
+    for (lin_vel, mut prev_lin_vel) in &mut lin_vel_query {
+        prev_lin_vel.0 = lin_vel.0;
+    }
+
+    for (ang_vel, mut prev_ang_vel) in &mut ang_vel_query {
+        prev_ang_vel.0 = ang_vel.0;
+    }
+}
 
 fn setup(
     mut commands: Commands,
@@ -63,13 +134,29 @@ fn setup(
 
     let mesh = meshes.add(Rectangle::from_length(60.0));
 
-    // This entity uses transform interpolation.
+    // This entity uses linear interpolation (`lerp` and `slerp`).
+    // Notice how it can cause entities to rotate in the wrong direction at high speeds,
+    // because `slerp` always takes the shortest path and doesn't account for full revolutions.
     commands.spawn((
-        Name::new("Interpolation"),
+        Name::new("Lerp + Slerp"),
         Mesh2d(mesh.clone()),
         MeshMaterial2d(materials.add(Color::from(CYAN_400)).clone()),
-        Transform::from_xyz(-500.0, 60.0, 0.0),
+        Transform::from_xyz(-500.0, 120.0, 0.0),
         TransformInterpolation,
+        LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
+        AngularVelocity(ROTATION_SPEED),
+    ));
+
+    // This entity uses Hermite interpolation.
+    commands.spawn((
+        Name::new("Hermite Interpolation"),
+        Mesh2d(mesh.clone()),
+        MeshMaterial2d(materials.add(Color::from(LIME_400)).clone()),
+        Transform::from_xyz(-500.0, 0.0, 0.0),
+        // Note: `TransformHermite` on its own does not perform interpolation.
+        //       Either `TransformInterpolation` or `TransformExtrapolation` must be present.
+        TransformInterpolation,
+        TransformHermite,
         LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
         AngularVelocity(ROTATION_SPEED),
     ));
@@ -79,7 +166,7 @@ fn setup(
         Name::new("No Interpolation"),
         Mesh2d(mesh.clone()),
         MeshMaterial2d(materials.add(Color::from(RED_400)).clone()),
-        Transform::from_xyz(-500.0, -60.0, 0.0),
+        Transform::from_xyz(-500.0, -120.0, 0.0),
         LinearVelocity(Vec2::new(MOVEMENT_SPEED, 0.0)),
         AngularVelocity(ROTATION_SPEED),
     ));
@@ -162,7 +249,7 @@ fn setup_text(mut commands: Commands) {
     ));
 
     commands.spawn((
-        Text::new("Interpolation"),
+        Text::new("Lerp + Slerp"),
         TextColor::from(CYAN_400),
         font.clone(),
         Node {
@@ -174,12 +261,24 @@ fn setup_text(mut commands: Commands) {
     ));
 
     commands.spawn((
+        Text::new("Hermite Interpolation"),
+        TextColor::from(LIME_400),
+        font.clone(),
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::Px(75.0),
+            left: Val::Px(10.0),
+            ..default()
+        },
+    ));
+
+    commands.spawn((
         Text::new("No Interpolation"),
         TextColor::from(RED_400),
         font.clone(),
         Node {
             position_type: PositionType::Absolute,
-            top: Val::Px(75.0),
+            top: Val::Px(100.0),
             left: Val::Px(10.0),
             ..default()
         },

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -338,7 +338,7 @@ pub struct RotationExtrapolation;
 fn reset_translation_extrapolation(
     mut query: Query<
         (&mut Transform, &TranslationEasingState),
-        (With<TransformExtrapolation>, Without<NoTranslationEasing>),
+        (With<TranslationExtrapolation>, Without<NoTranslationEasing>),
     >,
 ) {
     for (mut transform, translation_easing) in &mut query {
@@ -353,7 +353,7 @@ fn reset_translation_extrapolation(
 fn reset_rotation_extrapolation(
     mut query: Query<
         (&mut Transform, &RotationEasingState),
-        (With<TransformExtrapolation>, Without<NoRotationEasing>),
+        (With<RotationExtrapolation>, Without<NoRotationEasing>),
     >,
 ) {
     for (mut transform, rotation_easing) in &mut query {

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -1,0 +1,380 @@
+//! [`Transform`] extrapolation, making movement in [`FixedUpdate`] appear smooth
+//! by easing between the current and predicted [`Transform`] in between fixed timesteps.
+//!
+//! See the [`TransformExtrapolationPlugin`] for more information.
+
+use std::marker::PhantomData;
+
+use crate::{
+    RotationEasingState, TransformEasingPlugin, TransformEasingSet, TranslationEasingState,
+    VelocitySource, VelocitySourceItem,
+};
+use bevy::prelude::*;
+
+/// A plugin for [`Transform`] extrapolation, making movement in [`FixedUpdate`] appear smooth.
+///
+/// Transform extrapolation predicts future positions based on velocity, and applies easing
+/// between the current and predicted [`Transform`] in between fixed timesteps.
+/// This results in movement that looks smooth and feels responsive, but can stutter
+/// when the prediction is incorrect, such as when velocity changes abruptly.
+///
+/// This plugin requires the [`TransformEasingPlugin`] to function. It is automatically added
+/// if not already present in the app.
+///
+/// Note that unlike [`TransformInterpolationPlugin`], this plugin does *not* support scale easing.
+/// However, the [`ScaleInterpolation`] component can still be used even when translation and rotation are extrapolated.
+///
+/// [`TransformInterpolationPlugin`]: crate::interpolation::TransformInterpolationPlugin
+/// [`ScaleInterpolation`]: crate::interpolation::ScaleInterpolation
+///
+/// # Usage
+///
+/// Transform extrapolation requires velocity to predict future positions.
+/// Instead of providing its own velocity components, the [`TransformExtrapolationPlugin`]
+/// lets you specify your own velocity components that you manage yourself.
+///
+/// First, make sure you have components for velocity, and implement the [`VelocitySource`] trait on a [`QueryData`] type:
+///
+/// ```
+/// use bevy::{ecs::query::QueryData, prelude::*};
+/// use bevy_transform_interpolation::VelocitySource;
+///
+/// #[derive(Component)]
+/// struct LinearVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct AngularVelocity(Vec3);
+///
+/// #[derive(QueryData)]
+/// struct LinVelSource;
+///
+/// impl VelocitySource for LinVelSource {
+///     // Components storing the previous and current velocities.
+///     // Note: For extrapolation, the `Previous` component is not used, so we can make it the same as `Current`.
+///     type Previous = LinearVelocity;
+///     type Current = LinearVelocity;
+///
+///     fn previous(start: &Self::Previous) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn current(end: &Self::Current) -> Vec3 {
+///         end.0
+///     }
+/// }
+///
+/// #[derive(QueryData)]
+/// struct AngVelSource;
+///
+/// impl VelocitySource for AngVelSource {
+///     type Previous = AngularVelocity;
+///     type Current = AngularVelocity;
+///
+///     fn previous(start: &Self::Previous) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn current(end: &Self::Current) -> Vec3 {
+///         end.0
+///     }
+/// }
+/// ```
+///
+/// Then, add the [`TransformExtrapolationPlugin`] to the app with the velocity sources:
+///
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_transform_interpolation::prelude::*;
+///
+/// fn main() {
+///    let mut app = App::build();
+///
+///     app.add_plugins((
+///        TransformInterpolationPlugin::default(),
+///        TransformExtrapolationPlugin::<LinVelSource, AngVelSource>::default(),
+///    ));
+///
+///    // Optional: Insert velocity components automatically for entities with extrapolation.
+///    app.register_required_components::<TranslationExtrapolation, LinearVelocity>();
+///    app.register_required_components::<RotationExtrapolation, AngularVelocity>();
+///
+///    // ...
+///
+///    app.run();
+/// }
+/// ```
+///
+/// Transform extrapolation can now be enabled for a given entity by adding the [`TransformExtrapolation`] component:
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
+/// fn setup(mut commands: Commands) {
+///     // Extrapolate translation and rotation.
+///     commands.spawn((
+///         Transform::default(),
+///         TransformExtrapolation,
+///     ));
+/// }
+/// ```
+///
+/// Now, any changes made to the translation or rotation of the entity in [`FixedPreUpdate`], [`FixedUpdate`],
+/// or [`FixedPostUpdate`] will automatically be smoothed in between fixed timesteps.
+///
+/// Transform properties can also be extrapolated individually by adding the [`TranslationExtrapolation`]
+/// and [`RotationExtrapolation`] components.
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
+/// fn setup(mut commands: Commands) {
+///     // Only extrapolate translation.
+///     commands.spawn((Transform::default(), TranslationExtrapolation));
+///     
+///     // Only extrapolate rotation.
+///     commands.spawn((Transform::default(), RotationExtrapolation));
+/// }
+/// ```
+///
+/// If you want *all* entities with a [`Transform`] to be extrapolated by default, you can use
+/// [`TransformExtrapolationPlugin::extrapolate_all()`], or set the [`extrapolate_translation_all`]
+/// and [`extrapolate_rotation_all`] fields.
+///
+/// ```ignore
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
+/// fn main() {
+///    App::build()
+///       .add_plugins(TransformExtrapolationPlugin::<LinVelSource, AngVelSource> {
+///           // Extrapolate translation by default, but not rotation.
+///           extrapolate_translation_all: true,
+///           extrapolate_rotation_all: false,
+///       })
+///       // ...
+///       .run();
+/// }
+/// ```
+///
+/// When extrapolation is enabled for all entities by default, you can still opt out of it for individual entities
+/// by adding the [`NoTransformEasing`] component, or the individual [`NoTranslationEasing`] and [`NoRotationEasing`] components.
+///
+/// Note that changing [`Transform`] manually in any schedule that *doesn't* use a fixed timestep is also supported,
+/// but it is equivalent to teleporting, and disables extrapolation for the entity for the remainder of that fixed timestep.
+///
+/// [`QueryData`]: bevy::ecs::query::QueryData
+/// [`TransformExtrapolationPlugin::extrapolate_all()`]: TransformExtrapolationPlugin::extrapolate_all
+/// [`extrapolate_translation_all`]: TransformExtrapolationPlugin::extrapolate_translation_all
+/// [`extrapolate_rotation_all`]: TransformExtrapolationPlugin::extrapolate_rotation_all
+/// [`NoTransformEasing`]: crate::NoTransformEasing
+/// [`NoTranslationEasing`]: crate::NoTranslationEasing
+/// [`NoRotationEasing`]: crate::NoRotationEasing
+///
+/// # Alternatives
+///
+/// For many applications, the stutter caused by mispredictions in extrapolation may be undesirable.
+/// In these cases, the [`TransformInterpolationPlugin`] can be a better alternative.
+///
+/// Transform interpolation eases between the previous and current [`Transform`],
+/// resulting in movement that is always smooth and accurate. The downside is that the rendered
+/// positions can lag slightly behind the true positions, making movement feel delayed.
+///
+/// # Easing Backends
+///
+/// By default, transform extrapolation uses linear interpolation (`lerp`) for easing translation,
+/// and spherical linear interpolation (`slerp`) for easing rotation.
+///
+/// If the previous and current velocities are also available, it is possible to use *Hermite interpolation*
+/// with the [`TransformHermitePlugin`] to get smoother and more accurate easing. To enable Hermite interpolation
+/// for extrapolation, add the [`TransformHermite`] component to the entity in addition to the extrapolation components.
+///
+/// [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
+/// [`TransformHermite`]: crate::hermite::TransformHermite
+#[derive(Debug)]
+pub struct TransformExtrapolationPlugin<LinVel: VelocitySource, AngVel: VelocitySource> {
+    pub extrapolate_translation_all: bool,
+    pub extrapolate_rotation_all: bool,
+    pub _phantom: PhantomData<(LinVel, AngVel)>,
+}
+
+impl<LinVel: VelocitySource, AngVel: VelocitySource> Default
+    for TransformExtrapolationPlugin<LinVel, AngVel>
+{
+    fn default() -> Self {
+        Self {
+            extrapolate_translation_all: false,
+            extrapolate_rotation_all: false,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<LinVel: VelocitySource, AngVel: VelocitySource> TransformExtrapolationPlugin<LinVel, AngVel> {
+    /// Enables extrapolation for translation and rotation for all entities with the [`Transform`] component.
+    ///
+    /// This can be overridden for individual entities by adding the [`NoTransformEasing`] component,
+    /// or the individual [`NoTranslationEasing`] and [`NoRotationEasing`] components.
+    ///
+    /// [`NoTransformEasing`]: crate::NoTransformEasing
+    /// [`NoTranslationEasing`]: crate::NoTranslationEasing
+    /// [`NoRotationEasing`]: crate::NoRotationEasing
+    pub fn extrapolate_all() -> Self {
+        Self {
+            extrapolate_translation_all: true,
+            extrapolate_rotation_all: true,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
+    for TransformExtrapolationPlugin<LinVel, AngVel>
+{
+    fn build(&self, app: &mut App) {
+        //Register components.
+        app.register_type::<(
+            TransformExtrapolation,
+            TranslationExtrapolation,
+            RotationExtrapolation,
+        )>();
+
+        // Reset the transform to the start of the extrapolation at the beginning of the fixed timestep
+        // to match the true position from the end of the previous fixed tick.
+        app.add_systems(
+            FixedFirst,
+            reset_extrapolation.before(TransformEasingSet::Reset),
+        );
+
+        // Update the start and end state of the extrapolation at the end of the fixed timestep.
+        app.add_systems(
+            FixedLast,
+            (
+                update_translation_extrapolation_states::<LinVel>,
+                update_rotation_extrapolation_states::<AngVel>,
+            )
+                .in_set(TransformEasingSet::UpdateEnd),
+        );
+
+        // Insert extrapolation components automatically for all entities with a `Transform`
+        // if the corresponding global extrapolation is enabled.
+        if self.extrapolate_translation_all {
+            let _ = app.try_register_required_components::<Transform, TranslationExtrapolation>();
+        }
+        if self.extrapolate_rotation_all {
+            let _ = app.try_register_required_components::<Transform, RotationExtrapolation>();
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        // Add the `TransformEasingPlugin` if it hasn't been added yet.
+        // It performs the actual easing based on the start and end states set by the extrapolation.
+        if !app.is_plugin_added::<TransformEasingPlugin>() {
+            app.add_plugins(TransformEasingPlugin);
+        }
+    }
+}
+
+/// Enables [`Transform`] extrapolation for an entity, making changes to translation
+/// and rotation in [`FixedUpdate`] appear smooth.
+///
+/// Extrapolation only works for entities with velocity components.
+/// [`TransformExtrapolationPlugin`] must be added to the app with the appropriate velocity sources.
+///
+/// Unlike [`TransformInterpolation`], this does *not* support scale easing.
+/// However, the [`ScaleInterpolation`] component can still be used even when translation and rotation are extrapolated.
+///
+/// See the [`TransformExtrapolationPlugin`] for more information.
+///
+/// [`TransformInterpolation`]: crate::interpolation::TransformInterpolation
+/// [`ScaleInterpolation`]: crate::interpolation::ScaleInterpolation
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+#[require(TranslationExtrapolation, RotationExtrapolation)]
+pub struct TransformExtrapolation;
+
+/// Enables translation extrapolation for an entity, making changes to translation
+/// in [`FixedUpdate`] appear smooth.
+///
+/// Extrapolation only works for entities with velocity components.
+/// [`TransformExtrapolationPlugin`] must be added to the app with the appropriate velocity sources.
+///
+/// See the [`TransformExtrapolationPlugin`] for more information.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+#[require(TranslationEasingState)]
+pub struct TranslationExtrapolation;
+
+/// Enables rotation extrapolation for an entity, making changes to rotation
+/// in [`FixedUpdate`] appear smooth.
+///
+/// Extrapolation only works for entities with velocity components.
+/// [`TransformExtrapolationPlugin`] must be added to the app with the appropriate velocity sources.
+///
+/// See the [`TransformExtrapolationPlugin`] for more information.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+#[require(RotationEasingState)]
+pub struct RotationExtrapolation;
+
+/// Resets the transform to the start of the extrapolation at the beginning of the fixed timestep
+/// to match the true position from the end of the previous fixed tick.
+fn reset_extrapolation(
+    mut query: Query<
+        (
+            &mut Transform,
+            &TranslationEasingState,
+            &RotationEasingState,
+        ),
+        With<TransformExtrapolation>,
+    >,
+) {
+    for (mut transform, translation_easing, rotation_easing) in &mut query {
+        if let Some(start) = translation_easing.start {
+            transform.translation = start;
+        }
+        if let Some(start) = rotation_easing.start {
+            transform.rotation = start;
+        }
+    }
+}
+
+/// Updates the start and end states of the extrapolation for the next fixed timestep.
+fn update_translation_extrapolation_states<V: VelocitySource>(
+    mut query: Query<
+        (&Transform, &mut TranslationEasingState, &V::Current),
+        With<TranslationExtrapolation>,
+    >,
+    time: Res<Time>,
+) {
+    let delta_secs = time.delta_secs();
+
+    for (transform, mut translation_easing, end_vel) in &mut query {
+        translation_easing.start = Some(transform.translation);
+
+        // Extrapolate the next state based on the current state and velocities.
+        let lin_vel = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+        translation_easing.end = Some(transform.translation + lin_vel * delta_secs);
+    }
+}
+
+/// Updates the start and end states of the extrapolation for the next fixed timestep.
+fn update_rotation_extrapolation_states<V: VelocitySource>(
+    mut query: Query<
+        (&Transform, &mut RotationEasingState, &V::Current),
+        With<RotationExtrapolation>,
+    >,
+    time: Res<Time>,
+) {
+    let delta_secs = time.delta_secs();
+
+    for (transform, mut rotation_easing, end_vel) in &mut query {
+        rotation_easing.start = Some(transform.rotation);
+
+        // Extrapolate the next state based on the current state and velocities.
+        let ang_vel = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+        let scaled_axis = ang_vel * delta_secs;
+        rotation_easing.end = Some(transform.rotation * Quat::from_scaled_axis(scaled_axis));
+    }
+}

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -187,11 +187,11 @@ use bevy::prelude::*;
 /// and spherical linear interpolation (`slerp`) for easing rotation.
 ///
 /// If the previous and current velocities are also available, it is possible to use *Hermite interpolation*
-/// with the [`TransformHermitePlugin`] to get smoother and more accurate easing. To enable Hermite interpolation
-/// for extrapolation, add the [`TransformHermite`] component to the entity in addition to the extrapolation components.
+/// with the [`TransformHermiteEasingPlugin`] to get smoother and more accurate easing. To enable Hermite interpolation
+/// for extrapolation, add the [`TransformHermiteEasing`] component to the entity in addition to the extrapolation components.
 ///
-/// [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
-/// [`TransformHermite`]: crate::hermite::TransformHermite
+/// [`TransformHermiteEasingPlugin`]: crate::hermite::TransformHermiteEasingPlugin
+/// [`TransformHermiteEasing`]: crate::hermite::TransformHermiteEasing
 #[derive(Debug)]
 pub struct TransformExtrapolationPlugin<LinVel: VelocitySource, AngVel: VelocitySource> {
     /// If `true`, translation will be extrapolated for all entities with the [`Transform`] component by default.

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -5,8 +5,9 @@ use std::{f32::consts::TAU, marker::PhantomData};
 use bevy::prelude::*;
 
 use crate::{
-    NonlinearRotationEasing, NonlinearTranslationEasing, RotationEasingState, TransformEasingSet,
-    TranslationEasingState, VelocitySource, VelocitySourceItem,
+    NoRotationEasing, NoTranslationEasing, NonlinearRotationEasing, NonlinearTranslationEasing,
+    RotationEasingState, TransformEasingSet, TranslationEasingState, VelocitySource,
+    VelocitySourceItem,
 };
 
 /// A Hermite interpolation plugin for [`Transform`] easing.
@@ -236,12 +237,15 @@ pub struct RotationHermite;
 
 /// Eases the translations of entities with Hermite interpolation.
 fn ease_translation_hermite<V: VelocitySource>(
-    mut query: Query<(
-        &mut Transform,
-        &TranslationEasingState,
-        &V::Previous,
-        &V::Current,
-    )>,
+    mut query: Query<
+        (
+            &mut Transform,
+            &TranslationEasingState,
+            &V::Previous,
+            &V::Current,
+        ),
+        Without<NoTranslationEasing>,
+    >,
     time: Res<Time<Fixed>>,
 ) {
     let overstep = time.overstep_fraction();
@@ -261,12 +265,15 @@ fn ease_translation_hermite<V: VelocitySource>(
 
 /// Eases the rotations of entities with Hermite interpolation.
 fn ease_rotation_hermite<V: VelocitySource>(
-    mut query: Query<(
-        &mut Transform,
-        &RotationEasingState,
-        &V::Previous,
-        &V::Current,
-    )>,
+    mut query: Query<
+        (
+            &mut Transform,
+            &RotationEasingState,
+            &V::Previous,
+            &V::Current,
+        ),
+        Without<NoRotationEasing>,
+    >,
     time: Res<Time<Fixed>>,
 ) {
     let overstep = time.overstep_fraction();

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -153,6 +153,7 @@ use crate::{
 ///     ));
 /// }
 /// ```
+///
 /// [`QueryData`]: bevy::ecs::query::QueryData
 #[derive(Debug)]
 pub struct TransformHermiteEasingPlugin<LinVel: VelocitySource, AngVel: VelocitySource>(

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -182,7 +182,7 @@ impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
 
         // Perform easing.
         app.add_systems(
-            PostUpdate,
+            RunFixedMainLoop,
             (
                 ease_translation_hermite::<LinVel>,
                 ease_rotation_hermite::<AngVel>,

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -1,0 +1,383 @@
+//! Hermite interpolation for [`Transform`] easing.
+
+use std::{f32::consts::TAU, marker::PhantomData};
+
+use bevy::prelude::*;
+
+use crate::{
+    NonlinearRotationEasing, NonlinearTranslationEasing, RotationEasingState, TransformEasingSet,
+    TranslationEasingState, VelocitySource, VelocitySourceItem,
+};
+
+/// A Hermite interpolation plugin for [`Transform`] easing.
+///
+/// By default, [`TransformInterpolationPlugin`] and [`TransformExtrapolationPlugin`]
+/// use *linear interpolation* (`lerp`) for easing translation and scale,
+/// and *spherical linear interpolation* (`slerp`) for easing rotation.
+/// This is computationally efficient and works well for most cases.
+///
+/// However, for more accurate and reliable easing that works at arbitrary velocities,
+/// it may be preferable to use *Hermite interpolation*. It uses both position and velocity information
+/// to estimate the trajectories of entities, producing smoother results.
+///
+/// This plugin should be used alongside the [`TransformInterpolationPlugin`] and/or [`TransformExtrapolationPlugin`].
+/// The [`TransformEasingPlugin`] is also required, and it is automatically added if not already present in the app.
+///
+/// [`TransformInterpolationPlugin`]: crate::interpolation::TransformInterpolationPlugin
+/// [`TransformExtrapolationPlugin`]: crate::extrapolation::TransformExtrapolationPlugin
+/// [`TransformEasingPlugin`]: crate::TransformEasingPlugin
+///
+/// # Usage
+///
+/// Hermite interpolation requires velocity to produce accurate curves.
+/// Instead of providing its own velocity components, the [`TransformHermitePlugin`]
+/// lets you specify your own velocity components that you manage yourself.
+///
+/// First, make sure you have components for the previous and current velocity, and implement
+/// the [`VelocitySource`] trait on a [`QueryData`] type:
+///
+/// ```
+/// use bevy::{ecs::query::QueryData, prelude::*};
+/// use bevy_transform_interpolation::VelocitySource;
+///
+/// #[derive(Component)]
+/// struct PreviousLinearVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct PreviousAngularVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct LinearVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct AngularVelocity(Vec3);
+///
+/// #[derive(QueryData)]
+/// struct LinVelSource;
+///
+/// impl VelocitySource for LinVelSource {
+///     // Components storing the previous and current velocities.
+///     type Previous = PreviousLinearVelocity;
+///     type Current = LinearVelocity;
+///
+///     fn previous(start: &Self::Previous) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn current(end: &Self::Current) -> Vec3 {
+///         end.0
+///     }
+/// }
+///
+/// #[derive(QueryData)]
+/// struct AngVelSource;
+///
+/// impl VelocitySource for AngVelSource {
+///     type Previous = PreviousAngularVelocity;
+///     type Current = AngularVelocity;
+///
+///     fn previous(start: &Self::Previous) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn current(end: &Self::Current) -> Vec3 {
+///         end.0
+///     }
+/// }
+/// ```
+///
+/// Then, add the [`TransformHermitePlugin`] to the app with the velocity sources,
+/// along with the [`TransformInterpolationPlugin`] and/or [`TransformExtrapolationPlugin`]:
+///
+/// ```
+/// use bevy::prelude::*;
+/// use bevy_transform_interpolation::prelude::*;
+///
+/// fn main() {
+///    let mut app = App::build();
+///
+///     app.add_plugins((
+///        TransformInterpolationPlugin::default(),
+///        TransformHermitePlugin::<LinVelSource, AngVelSource>::default(),
+///    ));
+///
+///    // Optional: Insert velocity components automatically for entities with Hermite interpolation.
+///    app.register_required_components::<TranslationHermite, LinearVelocity>();
+///    app.register_required_components::<TranslationHermite, PreviousLinearVelocity>();
+///    app.register_required_components::<RotationHermite, AngularVelocity>();
+///    app.register_required_components::<RotationHermite, PreviousAngularVelocity>();
+///
+///    // ...
+///
+///    app.run();
+/// }
+/// ```
+///
+/// Hermite interpolation can now be used for any interpolated or extrapolated entity
+/// that has the velocity components by adding the [`TransformHermite`] component:
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
+/// fn setup(mut commands: Commands) {
+///     // Use Hermite interpolation for interpolating translation and rotation.
+///     commands.spawn((
+///         Transform::default(),
+///         TransformInterpolation,
+///         TransformHermite,
+///     ));
+/// }
+/// ```
+///
+/// Hermite interpolation can also be used for translation and rotation separately:
+///
+/// ```
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
+/// fn setup(mut commands: Commands) {
+///     // Use Hermite interpolation for interpolating translation.
+///     commands.spawn((
+///         Transform::default(),
+///         TranslationInterpolation,
+///         TranslationHermite,
+///     ));
+///
+///     // Use Hermite interpolation for interpolating rotation.
+///     commands.spawn((
+///         Transform::default(),
+///         RotationInterpolation,
+///         RotationHermite,
+///     ));
+/// }
+/// ```
+/// [`QueryData`]: bevy::ecs::query::QueryData
+#[derive(Debug)]
+pub struct TransformHermitePlugin<LinVel: VelocitySource, AngVel: VelocitySource>(
+    PhantomData<LinVel>,
+    PhantomData<AngVel>,
+);
+
+impl<LinVel: VelocitySource, AngVel: VelocitySource> Default
+    for TransformHermitePlugin<LinVel, AngVel>
+{
+    fn default() -> Self {
+        Self(PhantomData, PhantomData)
+    }
+}
+
+impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
+    for TransformHermitePlugin<LinVel, AngVel>
+{
+    fn build(&self, app: &mut App) {
+        // Register components.
+        app.register_type::<(TransformHermite, TranslationHermite, RotationHermite)>();
+
+        // Mark entities with Hermite interpolation as having nonlinear easing to disable linear easing.
+        let _ = app
+            .try_register_required_components::<TranslationHermite, NonlinearTranslationEasing>();
+        let _ = app.try_register_required_components::<RotationHermite, NonlinearRotationEasing>();
+
+        // Perform easing.
+        app.add_systems(
+            PostUpdate,
+            (
+                ease_translation_hermite::<LinVel>,
+                ease_rotation_hermite::<AngVel>,
+            )
+                .in_set(TransformEasingSet::Ease),
+        );
+    }
+}
+
+/// Enables [Hermite interpolation](TransformHermitePlugin) for the easing of the [`Transform`] of an entity.
+/// Must be used together with either [`TransformInterpolation`] or [`TransformExtrapolation`].
+///
+/// For the interpolation to work, the entity must have velocity components that are updated every frame,
+/// and the app must have a [`TransformHermitePlugin`] with the appropriate velocity sources added.
+///
+/// See the [`TransformHermitePlugin`] for more information.
+///
+/// [`TransformInterpolation`]: crate::interpolation::TransformInterpolation
+/// [`TransformExtrapolation`]: crate::extrapolation::TransformExtrapolation
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+#[require(TranslationHermite, RotationHermite)]
+pub struct TransformHermite;
+
+/// Enables [Hermite interpolation](TransformHermitePlugin) for the easing of the translation of an entity.
+/// Must be used together with [`TranslationInterpolation`] or [`TranslationExtrapolation`].
+///
+/// For the interpolation to work, the entity must have a linear velocity component that is updated every frame,
+/// and the app must have a [`TransformHermitePlugin`] with the appropriate velocity source added.
+///
+/// See the [`TransformHermitePlugin`] for more information.
+///
+/// [`TranslationInterpolation`]: crate::interpolation::TranslationInterpolation
+/// [`TranslationExtrapolation`]: crate::extrapolation::TranslationExtrapolation
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct TranslationHermite;
+
+/// Enables [Hermite interpolation](TransformHermitePlugin) for the easing of the rotation of an entity.
+/// Must be used together with [`RotationInterpolation`] or [`RotationExtrapolation`].
+///
+/// For the interpolation to work, the entity must have an angular velocity component that is updated every frame,
+/// and the app must have a [`TransformHermitePlugin`] with the appropriate velocity source added.
+///
+/// See the [`TransformHermitePlugin`] for more information.
+///
+/// [`RotationInterpolation`]: crate::interpolation::RotationInterpolation
+/// [`RotationExtrapolation`]: crate::extrapolation::RotationExtrapolation
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct RotationHermite;
+
+/// Eases the translations of entities with Hermite interpolation.
+fn ease_translation_hermite<V: VelocitySource>(
+    mut query: Query<(
+        &mut Transform,
+        &TranslationEasingState,
+        &V::Previous,
+        &V::Current,
+    )>,
+    time: Res<Time<Fixed>>,
+) {
+    let overstep = time.overstep_fraction();
+    let delta_secs = time.delta_secs();
+
+    query
+        .par_iter_mut()
+        .for_each(|(mut transform, interpolation, start_vel, end_vel)| {
+            if let (Some(start), Some(end)) = (interpolation.start, interpolation.end) {
+                let vel0 = <V::Item<'static> as VelocitySourceItem<V>>::previous(start_vel);
+                let vel1 = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+                transform.translation =
+                    hermite_vec3(start, end, delta_secs * vel0, delta_secs * vel1, overstep);
+            }
+        });
+}
+
+/// Eases the rotations of entities with Hermite interpolation.
+fn ease_rotation_hermite<V: VelocitySource>(
+    mut query: Query<(
+        &mut Transform,
+        &RotationEasingState,
+        &V::Previous,
+        &V::Current,
+    )>,
+    time: Res<Time<Fixed>>,
+) {
+    let overstep = time.overstep_fraction();
+    let delta_secs = time.delta_secs();
+
+    query
+        .par_iter_mut()
+        .for_each(|(mut transform, interpolation, start_vel, end_vel)| {
+            if let (Some(start), Some(end)) = (interpolation.start, interpolation.end) {
+                let vel0 = <V::Item<'static> as VelocitySourceItem<V>>::previous(start_vel);
+                let vel1 = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+                transform.rotation = hermite_quat(
+                    start,
+                    end,
+                    delta_secs * vel0,
+                    delta_secs * vel1,
+                    overstep,
+                    true,
+                );
+            }
+        });
+}
+
+/// Performs a cubic Hermite interpolation between two vectors `p0` and `p1` with velocities `v0` and `v1`
+/// based on the value at `t`.
+///
+/// When `t` is `0.0`, the result will be equal to `p0`. When `t` is `1.0`, the result will be equal to `p1`.
+pub fn hermite_vec3(p0: Vec3, p1: Vec3, v0: Vec3, v1: Vec3, t: f32) -> Vec3 {
+    // Reference:
+    //
+    // Holden, D. "Cubic Interpolation of Quaternions"
+    // https://theorangeduck.com/page/cubic-interpolation-quaternions
+    //
+    // The article is mostly about quaternions, but also describes Hermite interpolation for vectors.
+    // For quaternions, we use a different approach. See `hermite_quat`.
+
+    let t2 = t * t;
+    let t3 = t2 * t;
+
+    // Polynomial coefficients
+    let b0 = 2.0 * t3 - 3.0 * t2 + 1.0;
+    let b1 = 3.0 * t2 - 2.0 * t3;
+    let b2 = t3 - 2.0 * t2 + t;
+    let b3 = t3 - t2;
+
+    b0 * p0 + b1 * p1 + b2 * v0 + b3 * v1
+}
+
+/// Performs a cubic Hermite interpolation between quaternions `q0` and `q1`
+/// with angular velocities `w0` and `w1` based on the value at `t`.
+///
+/// Both quaternions and angular velocities should be in the global frame.
+/// The angular velocities should be normalized such that they represent the angle of rotation
+/// over the time step.
+///
+/// When `t` is `0.0`, the result will be equal to `q0`. When `t` is `1.0`, the result will be equal to `q1`.
+///
+/// If `unwrap` is `true`, the interpolation will work for arbitrarily large velocities
+/// and handle multiple full revolutions correctly. This is a bit more expensive,
+/// but can be important for high angular velocities.
+pub fn hermite_quat(qa: Quat, qb: Quat, w0: Vec3, w1: Vec3, t: f32, unwrap: bool) -> Quat {
+    // Reference:
+    //
+    // Kim M.-J. et al. "A General Construction Scheme for Unit Quaternion Curves with Simple High Order Derivatives".
+    // http://graphics.cs.cmu.edu/nsp/course/15-464/Fall05/papers/kimKimShin.pdf
+    //
+    // Note that the paper's angular velocities are defined in the local frame, but our values
+    // are in the global frame, so the order of multiplication for quaternions is reversed.
+
+    let t2 = t * t;
+    let t3 = t * t2;
+
+    // Cumulative Bernstein basis polynomials
+    let b1 = 1.0 - (1.0 - t).powi(3);
+    let b2 = 3.0 * t2 - 2.0 * t3;
+    let b3 = t3;
+
+    let w0_div_3 = w0 / 3.0;
+    let w1_div_3 = w1 / 3.0;
+
+    // Advance by a third from initial rotation, with initial velocity.
+    let q1 = Quat::from_scaled_axis(w0_div_3) * qa;
+
+    // Back off by a third from final rotation, with final velocity.
+    let q2 = Quat::from_scaled_axis(-w1_div_3) * qb;
+
+    // Calculate fractional rotation needed to go from q0 to q1.
+    // q1 = q0 * Quat(w01 / 3)
+    let mut w01_div_3 = (q2 * q1.inverse()).to_scaled_axis();
+
+    // Add multiples of 2π to the magnitude of w01 / 3 to minimize
+    // its distance to the average of w0 / 3 and w1 / 3.
+    if unwrap {
+        let average_w_div_3 = w0_div_3.midpoint(w1_div_3);
+        let w01_direction = w01_div_3.normalize_or_zero();
+
+        // Closest point along unit vector n from starting point a to target point p, where l is the distance:
+        //
+        // argmin(l) length(a + l n - p)^2
+        //
+        // 0 = d/dl length(a + l n - p)^2 = dot([a + l n - p], n)
+        //
+        // l dot(n, n) = l = dot(p - a, n)
+
+        let extra_angle = w01_direction.dot(average_w_div_3 - w01_div_3);
+        w01_div_3 += (extra_angle / TAU).round() * TAU * w01_direction;
+    }
+
+    // Rotate by b1 * dt / 3 at initial velocity, then by b2 * dt / 3 at w01, then by b3 * dt / 3 at final velocity.
+    Quat::from_scaled_axis(b3 * w1_div_3)
+        * Quat::from_scaled_axis(b2 * w01_div_3)
+        * Quat::from_scaled_axis(b1 * w0_div_3)
+        * qa
+}

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -1,10 +1,13 @@
-//! [`Transform`] interpolation, making movement in [`FixedUpdate`] appear smooth.
+//! [`Transform`] interpolation, making movement in [`FixedUpdate`] appear smooth
+//! by easing between the old and current [`Transform`] in between fixed timesteps.
 //!
 //! See the [`TransformInterpolationPlugin`] for more information.
 
 #![allow(clippy::type_complexity)]
 
-use crate::*;
+use crate::{
+    prelude::*, RotationEasingState, ScaleEasingState, TransformEasingSet, TranslationEasingState,
+};
 use bevy::prelude::*;
 
 /// A plugin for [`Transform`] interpolation, making movement in [`FixedUpdate`] appear smooth.
@@ -33,16 +36,16 @@ use bevy::prelude::*;
 /// }
 /// ```
 ///
-/// Now, any changes made to the [`Transform`] of the entity in [`FixedPreUpdate`], [`FixedUpdate`], or [`FixedPostUpdate`]
-/// will automatically be smoothed in between fixed timesteps.
+/// Now, any changes made to the [`Transform`] of the entity in [`FixedPreUpdate`], [`FixedUpdate`],
+/// or [`FixedPostUpdate`] will automatically be smoothed in between fixed timesteps.
 ///
-/// Transform properties can also be interpolated individually by adding the [`TranslationInterpolation`], [`RotationInterpolation`],
-/// and [`ScaleInterpolation`] components.
+/// Transform properties can also be interpolated individually by adding the [`TranslationInterpolation`],
+/// [`RotationInterpolation`], and [`ScaleInterpolation`] components.
 ///
 /// ```
-/// use bevy::prelude::*;
-/// use bevy_transform_interpolation::prelude::*;
-///
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
 /// fn setup(mut commands: Commands) {
 ///     // Only interpolate translation.
 ///     commands.spawn((Transform::default(), TranslationInterpolation));
@@ -66,10 +69,10 @@ use bevy::prelude::*;
 /// [`TransformInterpolationPlugin::interpolate_all()`], or set the [`interpolate_translation_all`],
 /// [`interpolate_rotation_all`], and [`interpolate_scale_all`] fields.
 ///
-/// ```
-/// use bevy::prelude::*;
-/// use bevy_transform_interpolation::prelude::*;
-///
+/// ```no_run
+/// # use bevy::prelude::*;
+/// # use bevy_transform_interpolation::prelude::*;
+/// #
 /// fn main() {
 ///    App::build()
 ///       .add_plugins(TransformInterpolationPlugin {
@@ -84,8 +87,8 @@ use bevy::prelude::*;
 /// ```
 ///
 /// When interpolation is enabled for all entities by default, you can still opt out of it for individual entities
-/// by adding the [`NoTransformInterpolation`] component, or the individual [`NoTranslationInterpolation`],
-/// [`NoRotationInterpolation`], and [`NoScaleInterpolation`] components.
+/// by adding the [`NoTransformEasing`] component, or the individual [`NoTranslationEasing`], [`NoRotationEasing`],
+/// and [`NoScaleEasing`] components.
 ///
 /// Note that changing [`Transform`] manually in any schedule that *doesn't* use a fixed timestep is also supported,
 /// but it is equivalent to teleporting, and disables interpolation for the entity for the remainder of that fixed timestep.
@@ -98,33 +101,41 @@ use bevy::prelude::*;
 ///
 /// For games where low latency is crucial for gameplay, such as in some first-person shooters
 /// or racing games, the small delay introduced by interpolation may be undesirable. In those cases,
-/// one option is to use *transform extrapolation*, which predicts future positions based on velocity.
-/// This can make movement appear more responsive, but can also lead to jittery movement when the prediction is incorrect.
+/// one option is to use the [`TransformExtrapolationPlugin`] instea.
 ///
-/// Because good extrapolation requires velocity, it is currently not a built-in feature for `bevy_transform_interpolation`.
-/// However, it is relatively straightforward to implement your own extrapolation system on top of the [`TransformEasingPlugin`].
-/// An example of this can be found in `examples/extrapolation.rs`.
+/// Transform extrapolation predicts future positions based on velocity, and applies easing between
+/// the current and predicted [`Transform`]. This results in movement that looks smooth and feels responsive,
+/// but can stutter when the prediction is incorrect, such as when velocity changes abruptly.
+///
+/// # Easing Backends
+///
+/// By default, transform interpolation uses linear interpolation (`lerp`) for easing translation and scale,
+/// and spherical linear interpolation (`slerp`) for easing rotation.
+///
+/// If the previous and current velocities are also available, it is possible to use [Hermite interpolation]
+/// with the [`TransformHermitePlugin`] to get smoother and more accurate easing. To enable Hermite interpolation,
+/// add the [`TransformHermite`] component to the entity in addition to the core interpolation components.
 #[derive(Debug, Default)]
 pub struct TransformInterpolationPlugin {
     /// If `true`, translation will be interpolated for all entities with the [`Transform`] component by default.
     ///
-    /// This can be overridden for individual entities by adding the [`NoTranslationInterpolation`] or [`NoTransformInterpolation`] component.
+    /// This can be overridden for individual entities by adding the [`NoTranslationEasing`] or [`NoTransformEasing`] component.
     pub interpolate_translation_all: bool,
     /// If `true`, rotation will be interpolated for all entities with the [`Transform`] component by default.
     ///
-    /// This can be overridden for individual entities by adding the [`NoRotationInterpolation`] or [`NoTransformInterpolation`] component.
+    /// This can be overridden for individual entities by adding the [`NoRotationEasing`] or [`NoTransformEasing`] component.
     pub interpolate_rotation_all: bool,
     /// If `true`, scale will be interpolated for all entities with the [`Transform`] component by default.
     ///
-    /// This can be overridden for individual entities by adding the [`NoScaleInterpolation`] or [`NoTransformInterpolation`] component.
+    /// This can be overridden for individual entities by adding the [`NoScaleEasing`] or [`NoTransformEasing`] component.
     pub interpolate_scale_all: bool,
 }
 
 impl TransformInterpolationPlugin {
     /// Enables interpolation for translation, rotation, and scale for all entities with the [`Transform`] component.
     ///
-    /// This can be overridden for individual entities by adding the [`NoTransformInterpolation`] component,
-    /// or the individual [`NoTranslationInterpolation`], [`NoRotationInterpolation`], and [`NoScaleInterpolation`] components.
+    /// This can be overridden for individual entities by adding the [`NoTransformEasing`] component,
+    /// or the individual [`NoTranslationEasing`], [`NoRotationEasing`], and [`NoScaleEasing`] components.
     pub const fn interpolate_all() -> Self {
         Self {
             interpolate_translation_all: true,
@@ -141,9 +152,6 @@ impl Plugin for TransformInterpolationPlugin {
             TranslationInterpolation,
             RotationInterpolation,
             ScaleInterpolation,
-            NoTranslationInterpolation,
-            NoRotationInterpolation,
-            NoScaleInterpolation,
         )>();
 
         app.add_systems(
@@ -238,60 +246,11 @@ pub struct RotationInterpolation;
 #[require(ScaleEasingState)]
 pub struct ScaleInterpolation;
 
-/// Explicitly marks this entity as having no transform interpolation.
-///
-/// This can be used to override the [`interpolate_translation_all`],
-/// [`interpolate_rotation_all`], and [`interpolate_scale_all`] properties
-/// of the [`TransformInterpolationPlugin`] for this entity.
-///
-/// [`interpolate_translation_all`]: TransformInterpolationPlugin::interpolate_translation_all
-/// [`interpolate_rotation_all`]: TransformInterpolationPlugin::interpolate_rotation_all
-/// [`interpolate_scale_all`]: TransformInterpolationPlugin::interpolate_scale_all
-///
-/// See the [`TransformInterpolationPlugin`] for more information.
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Debug, Default)]
-#[require(TranslationInterpolation, RotationInterpolation, ScaleInterpolation)]
-pub struct NoTransformInterpolation;
-
-/// Explicitly marks this entity as having translation interpolation disabled.
-///
-/// This can be used to override [`TransformInterpolationPlugin::interpolate_translation_all`]
-/// for this entity.
-///
-/// See the [`TransformInterpolationPlugin`] for more information.
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Debug, Default)]
-pub struct NoTranslationInterpolation;
-
-/// Explicitly marks this entity as having rotation interpolation disabled.
-///
-/// This can be used to override [`TransformInterpolationPlugin::interpolate_rotation_all`]
-/// for this entity.
-///
-/// See the [`TransformInterpolationPlugin`] for more information.
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Debug, Default)]
-pub struct NoRotationInterpolation;
-
-/// Explicitly marks this entity as having scale interpolation disabled.
-///
-/// This can be used to override [`TransformInterpolationPlugin::interpolate_scale_all`]
-/// for this entity.
-///
-/// See the [`TransformInterpolationPlugin`] for more information.
-#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
-#[reflect(Component, Debug, Default)]
-pub struct NoScaleInterpolation;
-
 /// Makes sure the previous translation easing is fully applied before the next easing starts.
 fn complete_translation_easing(
     mut query: Query<
         (&mut Transform, &TranslationEasingState),
-        (
-            With<TranslationInterpolation>,
-            Without<NoTranslationInterpolation>,
-        ),
+        (With<TranslationInterpolation>, Without<NoTranslationEasing>),
     >,
 ) {
     for (mut transform, easing) in &mut query {
@@ -306,10 +265,7 @@ fn complete_translation_easing(
 fn complete_rotation_easing(
     mut query: Query<
         (&mut Transform, &RotationEasingState),
-        (
-            With<RotationInterpolation>,
-            Without<NoRotationInterpolation>,
-        ),
+        (With<RotationInterpolation>, Without<NoRotationEasing>),
     >,
 ) {
     for (mut transform, easing) in &mut query {
@@ -324,7 +280,7 @@ fn complete_rotation_easing(
 fn complete_scale_easing(
     mut query: Query<
         (&mut Transform, &ScaleEasingState),
-        (With<ScaleInterpolation>, Without<NoScaleInterpolation>),
+        (With<ScaleInterpolation>, Without<NoScaleEasing>),
     >,
 ) {
     for (mut transform, easing) in &mut query {
@@ -338,10 +294,7 @@ fn complete_scale_easing(
 fn update_translation_interpolation_start(
     mut query: Query<
         (&Transform, &mut TranslationEasingState),
-        (
-            With<TranslationInterpolation>,
-            Without<NoTranslationInterpolation>,
-        ),
+        (With<TranslationInterpolation>, Without<NoTranslationEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {
@@ -352,10 +305,7 @@ fn update_translation_interpolation_start(
 fn update_translation_interpolation_end(
     mut query: Query<
         (&Transform, &mut TranslationEasingState),
-        (
-            With<TranslationInterpolation>,
-            Without<NoTranslationInterpolation>,
-        ),
+        (With<TranslationInterpolation>, Without<NoTranslationEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {
@@ -366,10 +316,7 @@ fn update_translation_interpolation_end(
 fn update_rotation_interpolation_start(
     mut query: Query<
         (&Transform, &mut RotationEasingState),
-        (
-            With<RotationInterpolation>,
-            Without<NoRotationInterpolation>,
-        ),
+        (With<RotationInterpolation>, Without<NoRotationEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {
@@ -380,10 +327,7 @@ fn update_rotation_interpolation_start(
 fn update_rotation_interpolation_end(
     mut query: Query<
         (&Transform, &mut RotationEasingState),
-        (
-            With<RotationInterpolation>,
-            Without<NoRotationInterpolation>,
-        ),
+        (With<RotationInterpolation>, Without<NoRotationEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {
@@ -394,7 +338,7 @@ fn update_rotation_interpolation_end(
 fn update_scale_interpolation_start(
     mut query: Query<
         (&Transform, &mut ScaleEasingState),
-        (With<ScaleInterpolation>, Without<NoScaleInterpolation>),
+        (With<ScaleInterpolation>, Without<NoScaleEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {
@@ -405,7 +349,7 @@ fn update_scale_interpolation_start(
 fn update_scale_interpolation_end(
     mut query: Query<
         (&Transform, &mut ScaleEasingState),
-        (With<ScaleInterpolation>, Without<NoScaleInterpolation>),
+        (With<ScaleInterpolation>, Without<NoScaleEasing>),
     >,
 ) {
     for (transform, mut easing) in &mut query {

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -113,8 +113,8 @@ use bevy::prelude::*;
 /// and spherical linear interpolation (`slerp`) for easing rotation.
 ///
 /// If the previous and current velocities are also available, it is possible to use [Hermite interpolation]
-/// with the [`TransformHermitePlugin`] to get smoother and more accurate easing. To enable Hermite interpolation,
-/// add the [`TransformHermite`] component to the entity in addition to the core interpolation components.
+/// with the [`TransformHermiteEasingPlugin`] to get smoother and more accurate easing. To enable Hermite interpolation,
+/// add the [`TransformHermiteEasing`] component to the entity in addition to the core interpolation components.
 #[derive(Debug, Default)]
 pub struct TransformInterpolationPlugin {
     /// If `true`, translation will be interpolated for all entities with the [`Transform`] component by default.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! - Granularly ease individual [`Transform`] properties to reduce unnecessary computation.
 //! - Apply easing to specific entities or to all entities.
 //! - Works out of the box with physics engines using fixed timesteps.
-//! - Optional [Hermite interpolation][`TransformHermitePlugin`] to produce more natural and accurate movement that considers velocity.
+//! - Optional [Hermite interpolation][`TransformHermiteEasingPlugin`] to produce more natural and accurate movement that considers velocity.
 //! - Extensible with custom easing backends.
 //!
 //! ## Getting Started
@@ -78,8 +78,8 @@
 //! - Granularly ease individual properties of the transform with [`TranslationInterpolation`], [`RotationInterpolation`], and [`ScaleInterpolation`].
 //! - Opt out of transform easing for individual entities with [`NoTranslationEasing`], [`NoRotationEasing`], and [`NoScaleEasing`].
 //! - Use extrapolation instead of interpolation with the [`TransformExtrapolationPlugin`] and its related components.
-//! - Use Hermite interpolation for more natural and accurate movement with the [`TransformHermitePlugin`].
-//! - Implement custom easing backends for your specific needs, similarly to how the [`TransformHermitePlugin`] is implemented.
+//! - Use Hermite interpolation for more natural and accurate movement with the [`TransformHermiteEasingPlugin`].
+//! - Implement custom easing backends for your specific needs, similarly to how the [`TransformHermiteEasingPlugin`] is implemented.
 //!
 //! ## How Does It Work?
 //!
@@ -115,11 +115,11 @@
 //! is used for rotation.
 //!
 //! However, thanks to the modular and flexible architecture, other easing methods can also be used.
-//! The [`TransformHermitePlugin`] provides an easing backend using Hermite interpolation,
+//! The [`TransformHermiteEasingPlugin`] provides an easing backend using Hermite interpolation,
 //! overwriting the linear interpolation for specific entities with the [`NonlinearTranslationEasing`]
 //! and [`NonlinearRotationEasing`] marker components. Custom easing solutions can be implemented using the same pattern.
 //!
-//! [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
+//! [`TransformHermiteEasingPlugin`]: crate::hermite::TransformHermiteEasingPlugin
 
 #![expect(clippy::needless_doctest_main)]
 #![expect(clippy::type_complexity)]
@@ -288,10 +288,10 @@ pub struct NonlinearTranslationEasing;
 pub struct NonlinearRotationEasing;
 
 /// A [`QueryData`] type for specifying the components that store velocity for easing.
-/// Required for [`TransformExtrapolationPlugin`] and [`TransformHermitePlugin`].
+/// Required for [`TransformExtrapolationPlugin`] and [`TransformHermiteEasingPlugin`].
 ///
 /// [`TransformExtrapolationPlugin`]: crate::extrapolation::TransformExtrapolationPlugin
-/// [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
+/// [`TransformHermiteEasingPlugin`]: crate::hermite::TransformHermiteEasingPlugin
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,10 +137,16 @@ pub mod hermite;
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
-    #[doc(hidden)]
+    #[doc(inline)]
     pub use crate::{
-        extrapolation::*, hermite::*, interpolation::*, NoRotationEasing, NoScaleEasing,
-        NoTransformEasing, NoTranslationEasing, TransformEasingPlugin,
+        extrapolation::*,
+        hermite::{
+            RotationHermiteEasing, TransformHermiteEasing, TransformHermiteEasingPlugin,
+            TranslationHermiteEasing,
+        },
+        interpolation::*,
+        NoRotationEasing, NoScaleEasing, NoTransformEasing, NoTranslationEasing,
+        TransformEasingPlugin,
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,15 @@
 //! # `bevy_transform_interpolation`
 //!
-//! A [`Transform`] interpolation library for fixed timesteps for the [Bevy game engine](https://bevyengine.org).
+//! A drop-in [`Transform`] interpolation solution for fixed timesteps for the [Bevy game engine](https://bevyengine.org).
 //!
 //! ## Features
 //!
-//! - Interpolate changes made to translation, rotation, and scale in [`FixedUpdate`].
-//! - Interpolate individual [`Transform`] properties to reduce unnecessary computation.
-//! - Apply interpolation to individual entities or to all entities.
+//! - Automatically smooth out movement in [`FixedPreUpdate`], [`FixedUpdate`], and [`FixedPostUpdate`].
+//! - Support for both [`Transform`] [interpolation](TransformInterpolationPlugin) and [extrapolation](TransformExtrapolationPlugin).
+//! - Granularly ease individual [`Transform`] properties to reduce unnecessary computation.
+//! - Apply easing to specific entities or to all entities.
 //! - Works out of the box with physics engines using fixed timesteps.
+//! - Optional [Hermite interpolation][`TransformHermitePlugin`] to produce more natural and accurate movement that considers velocity.
 //! - Extensible with custom easing backends.
 //!
 //! ## Getting Started
@@ -36,9 +38,9 @@
 //! By default, interpolation is only performed for entities with the [`TransformInterpolation`] component:
 //!
 //! ```
-//! use bevy::prelude::*;
-//! use bevy_transform_interpolation::prelude::*;
-//!
+//! # use bevy::prelude::*;
+//! # use bevy_transform_interpolation::prelude::*;
+//! #
 //! fn setup(mut commands: Commands) {
 //!     // Interpolate the entire transform: translation, rotation, and scale.
 //!     commands.spawn((
@@ -55,9 +57,9 @@
 //! [`TransformInterpolationPlugin::interpolate_all()`]:
 //!
 //! ```
-//! use bevy::prelude::*;
-//! use bevy_transform_interpolation::prelude::*;
-//!
+//! # use bevy::prelude::*;
+//! # use bevy_transform_interpolation::prelude::*;
+//! #
 //! fn main() {
 //!    App::build()
 //!       .add_plugins(TransformInterpolationPlugin::interpolate_all())
@@ -66,24 +68,18 @@
 //! }
 //! ```
 //!
-//! It is also possible to opt out of interpolation for individual entities, or even interpolate
-//! specific [`Transform`] properties granularly. See the documentation of the [`TransformInterpolationPlugin`]
-//! for more information.
+//! See the documentation of the [`TransformInterpolationPlugin`] for a more detailed overview of what it can do.
 //!
-//! ## Custom Easing Backends
+//! ## Advanced Usage
 //!
-//! Transforms are interpolated using easing functions, which are applied to the `start` and `end`
-//! of the [`TranslationEasingState`], [`RotationEasingState`], and [`ScaleEasingState`] components.
-//! These components are added and managed automatically for entities with the [`TransformInterpolation`] component.
+//! For a lot of applications, the functionality shown in the [Getting Started](#getting-started) guide might be all you need!
+//! However, `bevy_transform_interpolation` has a lot more to offer:
 //!
-//! In the earlier example, the [`TransformInterpolationPlugin`] was used to enable interpolation.
-//! However, the core easing logic and state management are actually handled by the automatically
-//! added [`TransformEasingPlugin`]. The [`TransformInterpolationPlugin`] only updates the `start`
-//! and `end` states of the easing.
-//!
-//! It is possible to replace interpolation with another approach, such as a `TransformExtrapolationPlugin`,
-//! while reusing the core easing logic of the [`TransformEasingPlugin`]. An example of this can be found in
-//! `examples/extrapolation.rs`.
+//! - Granularly ease individual properties of the transform with [`TranslationInterpolation`], [`RotationInterpolation`], and [`ScaleInterpolation`].
+//! - Opt out of transform easing for individual entities with [`NoTranslationEasing`], [`NoRotationEasing`], and [`NoScaleEasing`].
+//! - Use extrapolation instead of interpolation with the [`TransformExtrapolationPlugin`] and its related components.
+//! - Use Hermite interpolation for more natural and accurate movement with the [`TransformHermitePlugin`].
+//! - Implement custom easing backends for your specific needs, similarly to how the [`TransformHermitePlugin`] is implemented.
 //!
 //! ## How Does It Work?
 //!
@@ -99,40 +95,63 @@
 //! }
 //! ```
 //!
-//! - At the start of the [`FixedFirst`] schedule, the states are reset to `None`.
-//! - In [`FixedFirst`], for every entity with the [`TranslationInterpolation`] component, `start` is set to the current [`Transform`].
-//! - In [`FixedLast`], for every entity with the [`TranslationInterpolation`] component, `end` is set to the current [`Transform`].
+//! The states are updated by the [`TransformInterpolationPlugin`] or [`TransformExtrapolationPlugin`]
+//! depending on whether the entity has [`TransformInterpolation`] or [`TransformExtrapolation`] components.
 //!
-//! This way, `start` represents the "old" state, while `end` represents the "new" state after changes have been made to [`Transform`]
-//! in between [`FixedFirst`] and [`FixedLast`]. Rotation and scale are handled similarly.
+//! If interpolation is used:
 //!
-//! The actual easing is then performed in [`PostUpdate`], before Bevy's transform propagation systems. If the [`Transform`] is detected to have changed
-//! since the last easing run but *outside* of the fixed timestep schedules, the easing is reset to `None` to prevent overwriting the change.
+//! - In [`FixedFirst`], `start` is set to the current [`Transform`].
+//! - In [`FixedLast`], `end` is set to the current [`Transform`].
 //!
-//! Note that the core easing logic and components are intentionally not tied to interpolation directly.
-//! A physics engine could implement **transform extrapolation** using velocity and the same easing functionality,
-//! supplying its own `TranslationExtrapolation` and `RotationExtrapolation` components.
+//! If extrapolation is used:
+//!
+//! - In [`FixedLast`], `start` is set to the current [`Transform`], and `end` is set to the [`Transform`] predicted based on velocity.
+//!
+//! At the start of the [`FixedFirst`] schedule, the states are reset to `None`. If the [`Transform`] is detected to have changed
+//! since the last easing run but *outside* of the fixed timestep schedules, the easing is also reset to `None` to prevent overwriting the change.
+//!
+//! The actual easing is performed in [`PostUpdate`] in between fixed timesteps, before Bevy's transform propagation systems.
+//! By default, linear interpolation (`lerp`) is used for translation and scale, and spherical linear interpolation (`slerp`)
+//! is used for rotation.
+//!
+//! However, thanks to the modular and flexible architecture, other easing methods can also be used.
+//! The [`TransformHermitePlugin`] provides an easing backend using Hermite interpolation,
+//! overwriting the linear interpolation for specific entities with the [`NonlinearTranslationEasing`]
+//! and [`NonlinearRotationEasing`] marker components. Custom easing solutions can be implemented using the same pattern.
+//!
+//! [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
 
 #![allow(clippy::needless_doctest_main)]
 
+// Core interpolation and extrapolation plugins
+pub mod extrapolation;
 pub mod interpolation;
+
+// Easing backends
+// TODO: Catmull-Rom (like Hermite interpolation, but velocity is estimated from four points)
+pub mod hermite;
 
 /// The prelude.
 ///
 /// This includes the most common types in this crate, re-exported for your convenience.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::interpolation::*;
-    #[doc(hidden)]
-    pub use crate::TransformEasingPlugin;
+    pub use crate::{
+        extrapolation::*, hermite::*, interpolation::*, NoRotationEasing, NoScaleEasing,
+        NoTransformEasing, NoTranslationEasing, TransformEasingPlugin,
+    };
 }
 
+use std::marker::PhantomData;
+
 // For doc links.
+#[allow(unused_imports)]
+use extrapolation::*;
 #[allow(unused_imports)]
 use interpolation::*;
 
 use bevy::{
-    ecs::{component::Tick, system::SystemChangeTick},
+    ecs::{component::Tick, query::QueryData, system::SystemChangeTick},
     prelude::*,
 };
 
@@ -154,6 +173,9 @@ impl Plugin for TransformEasingPlugin {
             TranslationEasingState,
             RotationEasingState,
             ScaleEasingState,
+            NoTranslationEasing,
+            NoRotationEasing,
+            NoScaleEasing,
         )>();
 
         app.init_resource::<LastEasingTick>();
@@ -231,7 +253,160 @@ pub enum TransformEasingSet {
 
 /// A resource that stores the last tick when easing was performed.
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut)]
-struct LastEasingTick(Tick);
+pub struct LastEasingTick(Tick);
+
+/// Explicitly marks this entity as having no transform easing, disabling interpolation and/or extrapolation.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+#[require(NoTranslationEasing, NoRotationEasing, NoScaleEasing)]
+pub struct NoTransformEasing;
+
+/// Explicitly marks this entity as having no translation easing, disabling interpolation and/or extrapolation.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct NoTranslationEasing;
+
+/// Explicitly marks this entity as having no rotation easing, disabling interpolation and/or extrapolation.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct NoRotationEasing;
+
+/// Explicitly marks this entity as having no scale easing, disabling interpolation and/or extrapolation.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct NoScaleEasing;
+
+/// A marker component that indicates that the entity has non-linear translation easing,
+/// and linear easing should not be applied.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct NonlinearTranslationEasing;
+
+/// A marker component that indicates that the entity has non-linear rotation easing,
+/// and linear easing should not be applied.
+#[derive(Component, Clone, Copy, Debug, Default, PartialEq, Eq, Reflect)]
+#[reflect(Component, Debug, Default)]
+pub struct NonlinearRotationEasing;
+
+/// A [`QueryData`] type for specifying the components that store velocity for easing.
+/// Required for [`TransformExtrapolationPlugin`] and [`TransformHermitePlugin`].
+///
+/// [`TransformExtrapolationPlugin`]: crate::extrapolation::TransformExtrapolationPlugin
+/// [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
+///
+/// # Example
+///
+/// ```
+/// // Velocity components
+///
+/// #[derive(Component)]
+/// struct LinearVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct PreviousLinearVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct AngularVelocity(Vec3);
+///
+/// #[derive(Component)]
+/// struct PreviousAngularVelocity(Vec3);
+///
+/// // Velocity source for easing that uses linear velocity
+/// #[derive(QueryData)]
+/// struct LinVelSource;
+///
+/// impl VelocitySource for LinVelSource {
+///     type Start = PreviousLinearVelocity;
+///     type End = LinearVelocity;
+///
+///     fn start(start: &Self::Start) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn end(end: &Self::End) -> Vec3 {
+///         end.0
+///     }
+/// }
+///
+/// // Velocity source for easing that uses angular velocity
+/// #[derive(QueryData)]
+/// struct AngVelSource;
+///
+/// impl VelocitySource for AngVelSource {
+///     type Start = PreviousAngularVelocity;
+///     type End = AngularVelocity;
+///
+///     fn start(start: &Self::Start) -> Vec3 {
+///         start.0
+///     }
+///
+///     fn end(end: &Self::End) -> Vec3 {
+///         end.0
+///     }
+/// }
+/// ```
+///
+/// Some forms of easing such as extrapolation may not require the previous velocity.
+/// In such cases, the `Previous` component can be set to `()`, and `previous` can simply return `Vec3::ZERO`.
+pub trait VelocitySource: QueryData + Send + Sync + 'static {
+    /// The component that stores the previous velocity.
+    ///
+    /// This is not required for all easing backends, such as extrapolation.
+    /// In such cases, this can be set to `()`.
+    type Previous: Component;
+
+    /// The component that stores the current velocity.
+    type Current: Component;
+
+    /// Returns the previous velocity.
+    ///
+    /// This is not required for all easing backends, such as extrapolation.
+    /// In such cases, this can return `Vec3::ZERO`.
+    fn previous(start: &Self::Previous) -> Vec3;
+
+    /// Returns the current velocity.
+    fn current(end: &Self::Current) -> Vec3;
+}
+
+trait VelocitySourceItem<V>
+where
+    V: VelocitySource,
+{
+    fn previous(start: &V::Previous) -> Vec3;
+    fn current(end: &V::Current) -> Vec3;
+}
+
+impl<'a, V: VelocitySource> VelocitySourceItem<V> for V::Item<'a> {
+    fn previous(start: &V::Previous) -> Vec3 {
+        V::previous(start)
+    }
+
+    fn current(end: &V::Current) -> Vec3 {
+        V::current(end)
+    }
+}
+
+// Required so that `()` can be used as a "null" velocity source despite it not being a component itself.
+// This can be useful if you only want to use Hermite interpolation for rotation, for example.
+//
+// This must be public, because `VelocitySource::Start` and `VelocitySource::End` are public interfaces,
+// but you can't actually create this component since the stored value is private and there are no constructors.
+#[derive(Component)]
+#[doc(hidden)]
+pub struct DummyComponent(PhantomData<()>);
+
+impl VelocitySource for () {
+    type Previous = DummyComponent;
+    type Current = DummyComponent;
+
+    fn previous(_: &Self::Previous) -> Vec3 {
+        Vec3::ZERO
+    }
+
+    fn current(_: &Self::Current) -> Vec3 {
+        Vec3::ZERO
+    }
+}
 
 /// Stores the start and end states used for interpolating the translation of an entity.
 /// The change in translation is smoothed from `start` to `end` in between [`FixedUpdate`] runs.
@@ -373,7 +548,10 @@ fn reset_scale_easing(mut query: Query<&mut ScaleEasingState>) {
 
 /// Eases the translations of entities with linear interpolation.
 fn ease_translation_lerp(
-    mut query: Query<(&mut Transform, &TranslationEasingState)>,
+    mut query: Query<
+        (&mut Transform, &TranslationEasingState),
+        Without<NonlinearTranslationEasing>,
+    >,
     time: Res<Time<Fixed>>,
 ) {
     let overstep = time.overstep_fraction();
@@ -387,7 +565,7 @@ fn ease_translation_lerp(
 
 /// Eases the rotations of entities with spherical linear interpolation.
 fn ease_rotation_slerp(
-    mut query: Query<(&mut Transform, &RotationEasingState)>,
+    mut query: Query<(&mut Transform, &RotationEasingState), Without<NonlinearRotationEasing>>,
     time: Res<Time<Fixed>>,
 ) {
     let overstep = time.overstep_fraction();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ where
     fn current(end: &V::Current) -> Vec3;
 }
 
-impl<'a, V: VelocitySource> VelocitySourceItem<V> for V::Item<'a> {
+impl<V: VelocitySource> VelocitySourceItem<V> for V::Item<'_> {
     fn previous(start: &V::Previous) -> Vec3 {
         V::previous(start)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 //! - Opt out of transform easing for individual entities with [`NoTranslationEasing`], [`NoRotationEasing`], and [`NoScaleEasing`].
 //! - Use extrapolation instead of interpolation with the [`TransformExtrapolationPlugin`] and its related components.
 //! - Use Hermite interpolation for more natural and accurate movement with the [`TransformHermiteEasingPlugin`].
-//! - Implement custom easing backends for your specific needs, similarly to how the [`TransformHermiteEasingPlugin`] is implemented.
+//! - Implement custom easing backends for your specific needs.
 //!
 //! ## How Does It Work?
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,9 @@
 //!
 //! [`TransformHermitePlugin`]: crate::hermite::TransformHermitePlugin
 
-#![allow(clippy::needless_doctest_main)]
+#![expect(clippy::needless_doctest_main)]
+#![expect(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 // Core interpolation and extrapolation plugins
 pub mod extrapolation;
@@ -550,7 +552,10 @@ fn reset_scale_easing(mut query: Query<&mut ScaleEasingState>) {
 fn ease_translation_lerp(
     mut query: Query<
         (&mut Transform, &TranslationEasingState),
-        Without<NonlinearTranslationEasing>,
+        (
+            Without<NonlinearTranslationEasing>,
+            Without<NoTranslationEasing>,
+        ),
     >,
     time: Res<Time<Fixed>>,
 ) {
@@ -565,7 +570,10 @@ fn ease_translation_lerp(
 
 /// Eases the rotations of entities with spherical linear interpolation.
 fn ease_rotation_slerp(
-    mut query: Query<(&mut Transform, &RotationEasingState), Without<NonlinearRotationEasing>>,
+    mut query: Query<
+        (&mut Transform, &RotationEasingState),
+        (Without<NonlinearRotationEasing>, Without<NoRotationEasing>),
+    >,
     time: Res<Time<Fixed>>,
 ) {
     let overstep = time.overstep_fraction();
@@ -582,7 +590,10 @@ fn ease_rotation_slerp(
 }
 
 /// Eases the scales of entities with linear interpolation.
-fn ease_scale_lerp(mut query: Query<(&mut Transform, &ScaleEasingState)>, time: Res<Time<Fixed>>) {
+fn ease_scale_lerp(
+    mut query: Query<(&mut Transform, &ScaleEasingState), Without<NoScaleEasing>>,
+    time: Res<Time<Fixed>>,
+) {
     let overstep = time.overstep_fraction();
 
     query.iter_mut().for_each(|(mut transform, interpolation)| {


### PR DESCRIPTION
- Add `NonlinearTranslationEasing` and `NonlinearRotationEasing` components for disabling the default linear interpolation in favor of another easing backend.
- Add Hermite interpolation as an optional easing backend, using the previous and current velocity to produce smoother, more accurate and reliable trajectories.
  - The velocity information is retrieved with a user-specified `QueryData` type that implements the `VelocitySource` trait. This means that physics engines like Avian could just use their existing `LinearVelocity` and `AngularVelocity` components, and bevy_rapier could use `Velocity`.
- Extract the `TransformExtrapolationPlugin` from the `extrapolation` example into a proper built-in plugin that uses the user-specified `VelocitySource` for retrieving velocity information.
- Rename `NoTranslationInterpolation`, `NoRotationInterpolation`, and `NoScaleInterpolation` to `NoTranslationEasing`, `NoRotationEasing`, and `NoScaleEasing`, since they can also be used for extrapolation and disabling easing logic in general.
- Rework and improve docs further.