### PR TITLE
Perform easing after `FixedMain` loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ struct Position(Vec3);
 #[derive(Component, Deref, DerefMut)]
 struct OldPosition(Vec3);
 
-// Runs in `Update` or `PostUpdate`.
 fn interpolate_transforms(
     mut query: Query<(&mut Transform, &Position, &OldPosition)>,
     fixed_time: Res<Time<Fixed>>
@@ -158,8 +157,9 @@ pub struct TranslationEasingState {
 This way, `start` represents the "old" state, while `end` represents the "new" state after changes have been made to `Transform`
 in between `FixedFirst` and `FixedLast`. Rotation and scale are handled similarly.
 
-The easing is then performed in `PostUpdate`, before Bevy's transform propagation systems. If the `Transform` is detected to have changed
-since the last easing run but *outside* of the fixed timestep schedules, the easing is reset to `None` to prevent overwriting the change.
+The easing is then performed in `RunFixedMainLoop`, right after `FixedMain`, before `Update`.
+If the `Transform` is detected to have changed since the last easing run but *outside*
+of the fixed timestep schedules, the easing is reset to `None` to prevent overwriting the change.
 
 Note that the core easing logic and components are intentionally not tied to interpolation directly.
 A physics engine could implement **transform extrapolation** using velocity and the same easing functionality,


### PR DESCRIPTION
Fixes #2.
A working and up-to-date version of #1.

Currently, easing is performed in `PostUpdate`. This causes major issues if something else depends on the positions of interpolated objects, such as a camera that follows an entity in `Update`. This can be seen below.

https://github.com/user-attachments/assets/e3091d62-de37-4d03-bf62-2b55ab652829

(The frame of reference isn't very clear here, but the camera is following the cyan square, and the red square is stationary)

The problem here is that right after `FixedMain`, the transform of the entity matches the "gameplay transform", i.e. the end state of the interpolation, so the camera following logic in `Update` initially uses that. Then easing is performed in `PostUpdate`, which causes the entities to "snap back" to the start of the easing, making the camera's position incorrect, causing very noticeable visual artifacts.

To fix this frame delay, we should perform the interpolation right after the `FixedMain` loop, in `RunFixedMainLoopSystem::AfterFixedMainLoop`. No more artifacts!

https://github.com/user-attachments/assets/82491956-7204-4221-b3a2-936fcaab37d1

(Again, it looks like the red square is moving, but it's actually the cyan square)