### PR TITLE
Migrate to Bevy 0.16.0-rc.1 and add `no_std` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,25 @@ keywords = ["gamedev", "interpolation", "easing", "bevy"]
 categories = ["game-development"]
 
 [features]
-default = []
+default = ["std"]
+
+# Enable the Rust standard library.
+std = ["bevy/std"]
+
+# Enable `libm` math operations for `no_std` environments and cross-platform determinism.
+libm = ["bevy/libm"]
 
 # Enable data serialization/deserialization using `serde`.
 serialize = ["dep:serde", "bevy/serialize"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false }
+bevy = { version = "0.16.0-rc.1", default-features = false }
 
 # Serialization
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.16.0-rc.1", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_text",
     "bevy_ui",
@@ -36,3 +42,8 @@ bevy = { version = "0.15", default-features = false, features = [
     "bevy_window",
     "x11",
 ] }
+
+[lints.clippy]
+std_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+alloc_instead_of_core = "warn"

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ and `NonlinearRotationEasing` marker components. Custom easing solutions can be 
 
 ## Supported Bevy Versions
 
-| `bevy` | `bevy_transform_interpolation` |
-| ------ | ------------------------------ |
-| 0.15   | 0.1                            |
+| `bevy`  | `bevy_transform_interpolation` |
+| ------- | ------------------------------ |
+| 0.16 RC | main                           |
+| 0.15    | 0.1                            |
 
 ## License
 

--- a/examples/hermite_interpolation.rs
+++ b/examples/hermite_interpolation.rs
@@ -24,7 +24,7 @@ use bevy_transform_interpolation::{
 };
 
 const MOVEMENT_SPEED: f32 = 250.0;
-const ROTATION_SPEED: f32 = std::f32::consts::TAU * 3.0;
+const ROTATION_SPEED: f32 = core::f32::consts::TAU * 3.0;
 
 fn main() {
     let mut app = App::new();

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -3,7 +3,7 @@
 //!
 //! See the [`TransformExtrapolationPlugin`] for more information.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     NoRotationEasing, NoTranslationEasing, RotationEasingState, TransformEasingPlugin,

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -82,7 +82,7 @@ use bevy::prelude::*;
 ///
 /// Then, add the [`TransformExtrapolationPlugin`] to the app with the velocity sources:
 ///
-/// ```
+/// ```no_run
 /// use bevy::{ecs::query::QueryData, prelude::*};
 /// use bevy_transform_interpolation::{prelude::*, VelocitySource};
 /// #
@@ -130,6 +130,7 @@ use bevy::prelude::*;
 ///     app.add_plugins((
 ///        TransformInterpolationPlugin::default(),
 ///        TransformExtrapolationPlugin::<LinVelSource, AngVelSource>::default(),
+/// #      TimePlugin::default(),
 ///    ));
 ///
 ///    // Optional: Insert velocity components automatically for entities with extrapolation.

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -130,7 +130,7 @@ use bevy::prelude::*;
 ///     app.add_plugins((
 ///        TransformInterpolationPlugin::default(),
 ///        TransformExtrapolationPlugin::<LinVelSource, AngVelSource>::default(),
-/// #      TimePlugin::default(),
+/// #      bevy::time::TimePlugin::default(),
 ///    ));
 ///
 ///    // Optional: Insert velocity components automatically for entities with extrapolation.

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -146,7 +146,7 @@ use crate::{
 ///     app.add_plugins((
 ///        TransformInterpolationPlugin::default(),
 ///        TransformHermiteEasingPlugin::<LinVelSource, AngVelSource>::default(),
-/// #      TimePlugin::default(),
+/// #      bevy::time::TimePlugin::default(),
 ///    ));
 ///
 ///    // Optional: Insert velocity components automatically for entities with Hermite interpolation.

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -1,6 +1,6 @@
 //! Hermite interpolation for [`Transform`] easing.
 
-use std::{f32::consts::TAU, marker::PhantomData};
+use core::{f32::consts::TAU, marker::PhantomData};
 
 use bevy::prelude::*;
 use ops::FloatPow;

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -91,7 +91,7 @@ use crate::{
 /// Then, add the [`TransformHermiteEasingPlugin`] to the app with the velocity sources,
 /// along with the [`TransformInterpolationPlugin`] and/or [`TransformExtrapolationPlugin`]:
 ///
-/// ```
+/// ```no_run
 /// use bevy::{ecs::query::QueryData, prelude::*};
 /// use bevy_transform_interpolation::{prelude::*, VelocitySource};
 /// #
@@ -146,6 +146,7 @@ use crate::{
 ///     app.add_plugins((
 ///        TransformInterpolationPlugin::default(),
 ///        TransformHermiteEasingPlugin::<LinVelSource, AngVelSource>::default(),
+/// #      TimePlugin::default(),
 ///    ));
 ///
 ///    // Optional: Insert velocity components automatically for entities with Hermite interpolation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,9 +121,15 @@
 //!
 //! [`TransformHermiteEasingPlugin`]: crate::hermite::TransformHermiteEasingPlugin
 
+#![no_std]
 #![expect(clippy::needless_doctest_main)]
 #![expect(clippy::type_complexity)]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 // Core interpolation and extrapolation plugins
 pub mod extrapolation;
@@ -150,7 +156,7 @@ pub mod prelude {
     };
 }
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 // For doc links.
 #[allow(unused_imports)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,11 +126,6 @@
 #![expect(clippy::type_complexity)]
 #![warn(missing_docs)]
 
-#[cfg(feature = "std")]
-extern crate std;
-
-extern crate alloc;
-
 // Core interpolation and extrapolation plugins
 pub mod extrapolation;
 pub mod interpolation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,13 +56,14 @@
 //! If you want *all* entities with a [`Transform`] to be interpolated by default, you can use
 //! [`TransformInterpolationPlugin::interpolate_all()`]:
 //!
-//! ```
+//! ```no_run
 //! # use bevy::prelude::*;
 //! # use bevy_transform_interpolation::prelude::*;
 //! #
 //! fn main() {
 //!    App::new()
 //!       .add_plugins(TransformInterpolationPlugin::interpolate_all())
+//! #     .add_plugins(TimePlugin::default())
 //!       // ...
 //!       .run();
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! fn main() {
 //!    App::new()
 //!       .add_plugins(TransformInterpolationPlugin::interpolate_all())
-//! #     .add_plugins(TimePlugin::default())
+//! #     .add_plugins(bevy::time::TimePlugin::default())
 //!       // ...
 //!       .run();
 //! }


### PR DESCRIPTION
# Objective

The first release candidate for Bevy 0.16 has been released! We should migrate our main branch to it.

Bevy 0.16 also adds `no_std` support. We need to enable some feature flags for this anyway, so I decided to add `no_std` support on our side in this PR directly since the changes are so trivial,

## Solution

Migrate to Bevy 0.16.0-rc.1, and add the `std` and `libm` features to support `no_std` environments.

---

## Migration Guide

`bevy_transform_interpolation` now has `no_std` support.

If you have default features disabled, you must either enable the `std` feature for the Rust standard library or the `libm` feature for math in `no_std` environments.