### PR TITLE
Check `no_std` compatibility in CI and fix remaining use of `std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,44 +1,61 @@
 name: CI
 
 on:
-    push:
-        branches:
-            - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    check:
-        name: Check
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo check
-              run: cargo check
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo check
+        run: cargo check
 
-    test:
-        name: Test Suite
-        strategy:
-            matrix:
-                os: [windows-latest, ubuntu-latest, macos-latest]
-        runs-on: ${{ matrix.os }}
-        timeout-minutes: 60
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo test
-              run: cargo test --all-features
+  check-compiles-no-std:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - "x86_64-unknown-none"
+          - "wasm32v1-none"
+          - "thumbv6m-none-eabi"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Run cargo check
+        run: cargo check --no-default-features --features libm --target ${{ matrix.target }}
 
-    lints:
-        name: Lints
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: dtolnay/rust-toolchain@stable
-            - name: Run cargo fmt
-              run: cargo fmt --all -- --check
-            - name: Run cargo clippy
-              run: cargo clippy -- -D warnings
+  test:
+    name: Test Suite
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo test
+        run: cargo test --all-features
+
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Run cargo check
-        run: cargo check --no-default-features --features libm --target ${{ matrix.target }}
+        run: cargo check --no-default-features --features libm,critical-section --target ${{ matrix.target }}
 
   test:
     name: Test Suite

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,17 @@ categories = ["game-development"]
 [features]
 default = ["std"]
 
+# Enable data serialization/deserialization using `serde`.
+serialize = ["dep:serde", "bevy/serialize"]
+
 # Enable the Rust standard library.
 std = ["bevy/std"]
 
 # Enable `libm` math operations for `no_std` environments and cross-platform determinism.
 libm = ["bevy/libm"]
 
-# Enable data serialization/deserialization using `serde`.
-serialize = ["dep:serde", "bevy/serialize"]
+# Rely on `critical-section` for synchronization primitives.
+critical-section = ["bevy/critical-section"]
 
 [dependencies]
 bevy = { version = "0.16.0-rc.1", default-features = false }

--- a/clippy.toml
+++ b/clippy.toml
@@ -26,4 +26,13 @@ disallowed-methods = [
     { path = "f32::asinh", reason = "use ops::asinh instead for libm determinism" },
     { path = "f32::acosh", reason = "use ops::acosh instead for libm determinism" },
     { path = "f32::atanh", reason = "use ops::atanh instead for libm determinism" },
+    # These methods have defined precision, but are only available from the standard library,
+    # not in core. Using these substitutes allows for no_std compatibility.
+    { path = "f32::rem_euclid", reason = "use ops::rem_euclid instead for no_std compatibility" },
+    { path = "f32::abs", reason = "use ops::abs instead for no_std compatibility" },
+    { path = "f32::sqrt", reason = "use ops::sqrt instead for no_std compatibility" },
+    { path = "f32::copysign", reason = "use ops::copysign instead for no_std compatibility" },
+    { path = "f32::round", reason = "use ops::round instead for no_std compatibility" },
+    { path = "f32::floor", reason = "use ops::floor instead for no_std compatibility" },
+    { path = "f32::fract", reason = "use ops::fract instead for no_std compatibility" },
 ]

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -432,7 +432,7 @@ pub fn hermite_quat(qa: Quat, qb: Quat, w0: Vec3, w1: Vec3, t: f32, unwrap: bool
         // l dot(n, n) = l = dot(p - a, n)
 
         let extra_angle = w01_direction.dot(average_w_div_3 - w01_div_3);
-        w01_div_3 += (extra_angle / TAU).round() * TAU * w01_direction;
+        w01_div_3 += ops::round(extra_angle / TAU) * TAU * w01_direction;
     }
 
     // Rotate by b1 * dt / 3 at initial velocity, then by b2 * dt / 3 at w01, then by b3 * dt / 3 at final velocity.


### PR DESCRIPTION
# Objective

It can be easy to accidentally break `no_std` compatibility. We should check it in CI!

We're also missing some `f32` method lints in `clippy.toml`, and are still actually using `std::f32::round` in one place.

## Solution

Add `no_std` checks to CI, and add the remaining `f32` method lints to `clippy.toml`. Through this I also discovered that we need a `critical-section` feature for Bevy in some `no_std` environments.

The check is based on [`no_std` library example](https://github.com/bevyengine/bevy/tree/0244a841b78ea9a995880fea6733da21a6c0fea2/examples/no_std/library).