### PR TITLE
Release 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_transform_interpolation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Joona Aalto <jondolf.dev@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ libm = ["bevy/libm"]
 critical-section = ["bevy/critical-section"]
 
 [dependencies]
-bevy = { version = "0.16.0-rc", default-features = false }
+bevy = { version = "0.16", default-features = false }
 
 # Serialization
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16.0-rc", default-features = false, features = [
+bevy = { version = "0.16", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_text",
     "bevy_ui",

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ and `NonlinearRotationEasing` marker components. Custom easing solutions can be 
 
 | `bevy`  | `bevy_transform_interpolation` |
 | ------- | ------------------------------ |
-| 0.16 RC | main                           |
+| 0.16    | 0.2                            |
 | 0.15    | 0.1                            |
 
 ## License


### PR DESCRIPTION
# Objective

Closes #11.

We need to make a 0.2 release with Bevy 0.16 support.

## Solution

Do that :)