### PR TITLE
Fix typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn interpolate_transforms(
 
     for (mut transform, position, old_position) in &mut query {
         // Linearly interpolate the translation from the old position to the current one.
-        transform.translation = old_position.lerp(position.0, overstep_fraction);
+        transform.translation = old_position.lerp(position.0, overstep);
     }
 }
 ```


### PR DESCRIPTION
# Objective

- Snippet example mentions `overstep_fraction`, which is not defined.

## Solution

- Replace `overstep_fraction` with `overstep`, which is the correct variable already defined above.