### PR TITLE
Update to Bevy 0.17 RC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
       matrix:
         target:
           - "x86_64-unknown-none"
-          - "wasm32v1-none"
+          # TODO: Re-enable this when it is supported again.
+          # - "wasm32v1-none"
           - "thumbv6m-none-eabi"
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,19 +27,20 @@ libm = ["bevy/libm"]
 critical-section = ["bevy/critical-section"]
 
 [dependencies]
-bevy = { version = "0.16", default-features = false }
+bevy = { version = "0.17.0-rc", default-features = false }
 
 # Serialization
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.16", default-features = false, features = [
+bevy = { version = "0.17.0-rc", default-features = false, features = [
     "bevy_core_pipeline",
     "bevy_text",
     "bevy_ui",
     "bevy_asset",
     "bevy_render",
     "bevy_sprite",
+    "bevy_sprite_render",
     "default_font",
     "bevy_winit",
     "bevy_window",

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ First, add `bevy_transform_interpolation` to your dependencies in `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy_transform_interpolation = "0.1"
+bevy_transform_interpolation = "0.2"
 ```
 
 To enable `Transform` interpolation, add the `TransformInterpolationPlugin` to your app:
@@ -156,6 +156,7 @@ and `NonlinearRotationEasing` marker components. Custom easing solutions can be 
 
 | `bevy`  | `bevy_transform_interpolation` |
 | ------- | ------------------------------ |
+| 0.17    | `main`                         |
 | 0.16    | 0.2                            |
 | 0.15    | 0.1                            |
 

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -416,7 +416,7 @@ fn update_translation_extrapolation_states<V: VelocitySource>(
         translation_easing.start = Some(transform.translation);
 
         // Extrapolate the next state based on the current state and velocities.
-        let lin_vel = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+        let lin_vel = <V::Item<'static, 'static> as VelocitySourceItem<V>>::current(end_vel);
         translation_easing.end = Some(transform.translation + lin_vel * delta_secs);
     }
 }
@@ -435,7 +435,7 @@ fn update_rotation_extrapolation_states<V: VelocitySource>(
         rotation_easing.start = Some(transform.rotation);
 
         // Extrapolate the next state based on the current state and velocities.
-        let ang_vel = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+        let ang_vel = <V::Item<'static, 'static> as VelocitySourceItem<V>>::current(end_vel);
         let scaled_axis = ang_vel * delta_secs;
         rotation_easing.end = Some(transform.rotation * Quat::from_scaled_axis(scaled_axis));
     }

--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 
 use crate::{
     NoRotationEasing, NoTranslationEasing, RotationEasingState, TransformEasingPlugin,
-    TransformEasingSet, TranslationEasingState, VelocitySource, VelocitySourceItem,
+    TransformEasingSystems, TranslationEasingState, VelocitySource, VelocitySourceItem,
 };
 use bevy::prelude::*;
 
@@ -298,7 +298,7 @@ impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
                 reset_translation_extrapolation,
                 reset_rotation_extrapolation,
             )
-                .before(TransformEasingSet::Reset),
+                .before(TransformEasingSystems::Reset),
         );
 
         // Update the start and end state of the extrapolation at the end of the fixed timestep.
@@ -308,7 +308,7 @@ impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
                 update_translation_extrapolation_states::<LinVel>,
                 update_rotation_extrapolation_states::<AngVel>,
             )
-                .in_set(TransformEasingSet::UpdateEnd),
+                .in_set(TransformEasingSystems::UpdateEnd),
         );
 
         // Insert extrapolation components automatically for all entities with a `Transform`

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -7,7 +7,7 @@ use ops::FloatPow;
 
 use crate::{
     NoRotationEasing, NoTranslationEasing, NonlinearRotationEasing, NonlinearTranslationEasing,
-    RotationEasingState, TransformEasingSet, TranslationEasingState, VelocitySource,
+    RotationEasingState, TransformEasingSystems, TranslationEasingState, VelocitySource,
     VelocitySourceItem,
 };
 
@@ -240,7 +240,7 @@ impl<LinVel: VelocitySource, AngVel: VelocitySource> Plugin
                 ease_translation_hermite::<LinVel>,
                 ease_rotation_hermite::<AngVel>,
             )
-                .in_set(TransformEasingSet::Ease),
+                .in_set(TransformEasingSystems::Ease),
         );
     }
 }

--- a/src/hermite.rs
+++ b/src/hermite.rs
@@ -308,8 +308,9 @@ fn ease_translation_hermite<V: VelocitySource>(
         .par_iter_mut()
         .for_each(|(mut transform, interpolation, start_vel, end_vel)| {
             if let (Some(start), Some(end)) = (interpolation.start, interpolation.end) {
-                let vel0 = <V::Item<'static> as VelocitySourceItem<V>>::previous(start_vel);
-                let vel1 = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+                let vel0 =
+                    <V::Item<'static, 'static> as VelocitySourceItem<V>>::previous(start_vel);
+                let vel1 = <V::Item<'static, 'static> as VelocitySourceItem<V>>::current(end_vel);
                 transform.translation =
                     hermite_vec3(start, end, delta_secs * vel0, delta_secs * vel1, overstep);
             }
@@ -336,8 +337,9 @@ fn ease_rotation_hermite<V: VelocitySource>(
         .par_iter_mut()
         .for_each(|(mut transform, interpolation, start_vel, end_vel)| {
             if let (Some(start), Some(end)) = (interpolation.start, interpolation.end) {
-                let vel0 = <V::Item<'static> as VelocitySourceItem<V>>::previous(start_vel);
-                let vel1 = <V::Item<'static> as VelocitySourceItem<V>>::current(end_vel);
+                let vel0 =
+                    <V::Item<'static, 'static> as VelocitySourceItem<V>>::previous(start_vel);
+                let vel1 = <V::Item<'static, 'static> as VelocitySourceItem<V>>::current(end_vel);
                 transform.rotation = hermite_quat(
                     start,
                     end,

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -6,7 +6,8 @@
 #![allow(clippy::type_complexity)]
 
 use crate::{
-    prelude::*, RotationEasingState, ScaleEasingState, TransformEasingSystems, TranslationEasingState,
+    prelude::*, RotationEasingState, ScaleEasingState, TransformEasingSystems,
+    TranslationEasingState,
 };
 use bevy::prelude::*;
 

--- a/src/interpolation.rs
+++ b/src/interpolation.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::type_complexity)]
 
 use crate::{
-    prelude::*, RotationEasingState, ScaleEasingState, TransformEasingSet, TranslationEasingState,
+    prelude::*, RotationEasingState, ScaleEasingState, TransformEasingSystems, TranslationEasingState,
 };
 use bevy::prelude::*;
 
@@ -162,7 +162,7 @@ impl Plugin for TransformInterpolationPlugin {
                 complete_scale_easing,
             )
                 .chain()
-                .before(TransformEasingSet::Reset),
+                .before(TransformEasingSystems::Reset),
         );
 
         // Update the start state of the interpolation at the start of the fixed timestep.
@@ -174,7 +174,7 @@ impl Plugin for TransformInterpolationPlugin {
                 update_scale_interpolation_start,
             )
                 .chain()
-                .in_set(TransformEasingSet::UpdateStart),
+                .in_set(TransformEasingSystems::UpdateStart),
         );
 
         // Update the end state of the interpolation at the end of the fixed timestep.
@@ -186,7 +186,7 @@ impl Plugin for TransformInterpolationPlugin {
                 update_scale_interpolation_end,
             )
                 .chain()
-                .in_set(TransformEasingSet::UpdateEnd),
+                .in_set(TransformEasingSystems::UpdateEnd),
         );
 
         // Insert interpolation components automatically for all entities with a `Transform`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,18 +193,22 @@ impl Plugin for TransformEasingPlugin {
         // Reset easing states and update start values at the start of the fixed timestep.
         app.configure_sets(
             FixedFirst,
-            (TransformEasingSet::Reset, TransformEasingSet::UpdateStart).chain(),
+            (
+                TransformEasingSystems::Reset,
+                TransformEasingSystems::UpdateStart,
+            )
+                .chain(),
         );
 
         // Update end values at the end of the fixed timestep.
-        app.configure_sets(FixedLast, TransformEasingSet::UpdateEnd);
+        app.configure_sets(FixedLast, TransformEasingSystems::UpdateEnd);
 
         // Perform transform easing right after the fixed timestep, before `Update`.
         app.configure_sets(
             RunFixedMainLoop,
             (
-                TransformEasingSet::Ease,
-                TransformEasingSet::UpdateEasingTick,
+                TransformEasingSystems::Ease,
+                TransformEasingSystems::UpdateEasingTick,
             )
                 .chain()
                 .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
@@ -219,32 +223,32 @@ impl Plugin for TransformEasingPlugin {
                 reset_scale_easing,
             )
                 .chain()
-                .in_set(TransformEasingSet::Reset),
+                .in_set(TransformEasingSystems::Reset),
         );
 
         app.add_systems(
             RunFixedMainLoop,
-            reset_easing_states_on_transform_change.before(TransformEasingSet::Ease),
+            reset_easing_states_on_transform_change.before(TransformEasingSystems::Ease),
         );
 
         // Perform easing.
         app.add_systems(
             RunFixedMainLoop,
             (ease_translation_lerp, ease_rotation_slerp, ease_scale_lerp)
-                .in_set(TransformEasingSet::Ease),
+                .in_set(TransformEasingSystems::Ease),
         );
 
         // Update the last easing tick.
         app.add_systems(
             RunFixedMainLoop,
-            update_last_easing_tick.in_set(TransformEasingSet::UpdateEasingTick),
+            update_last_easing_tick.in_set(TransformEasingSystems::UpdateEasingTick),
         );
     }
 }
 
-/// A system set for easing transform.
+/// System sets for easing transform.
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum TransformEasingSet {
+pub enum TransformEasingSystems {
     /// Resets easing states to `None` at the start of the fixed timestep.
     Reset,
     /// Updates the `start` values for easing at the start of the fixed timestep.
@@ -257,6 +261,10 @@ pub enum TransformEasingSet {
     /// Updates [`LastEasingTick`], the last tick when easing was performed.
     UpdateEasingTick,
 }
+
+/// A deprecated alias for [`TransformEasingSystems`].
+#[deprecated(since = "0.3.0", note = "Renamed to `TransformEasingSystems`")]
+pub type TransformEasingSet = TransformEasingSystems;
 
 /// A resource that stores the last tick when easing was performed.
 #[derive(Resource, Clone, Copy, Debug, Default, Deref, DerefMut)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,7 @@ impl Plugin for TransformEasingPlugin {
                 TransformEasingSet::UpdateEasingTick,
             )
                 .chain()
-                .in_set(RunFixedMainLoopSystem::AfterFixedMainLoop),
+                .in_set(RunFixedMainLoopSystems::AfterFixedMainLoop),
         );
 
         // Reset easing states.
@@ -386,7 +386,7 @@ where
     fn current(end: &V::Current) -> Vec3;
 }
 
-impl<V: VelocitySource> VelocitySourceItem<V> for V::Item<'_> {
+impl<V: VelocitySource> VelocitySourceItem<V> for V::Item<'_, '_> {
     fn previous(start: &V::Previous) -> Vec3 {
         V::previous(start)
     }


### PR DESCRIPTION
# Objective

Update to the Bevy 0.17 release candidate.

## Solution

Update dependencies, rename `TransformEasingSet` to `TransformEasingSystems`.

---

## Migration Guide

`TransformEasingSet` has been renamed to `TransformEasingSystems`.