### PR TITLE
Rotation extrapolation fix

### DIFF
--- a/src/extrapolation.rs
+++ b/src/extrapolation.rs
@@ -437,6 +437,6 @@ fn update_rotation_extrapolation_states<V: VelocitySource>(
         // Extrapolate the next state based on the current state and velocities.
         let ang_vel = <V::Item<'static, 'static> as VelocitySourceItem<V>>::current(end_vel);
         let scaled_axis = ang_vel * delta_secs;
-        rotation_easing.end = Some(transform.rotation * Quat::from_scaled_axis(scaled_axis));
+        rotation_easing.end = Some(Quat::from_scaled_axis(scaled_axis) * transform.rotation);
     }
 }


### PR DESCRIPTION
## Solution

- Use the correct multiplication order for quaternions.

**Before**
[before.webm](https://github.com/user-attachments/assets/a6f23c27-d420-4f2d-9115-3a7f51d5bcb3)

**After**
[after.webm](https://github.com/user-attachments/assets/7448336d-586d-4bb1-a5e1-f5ba9edd637d)



## Changelog

Fixed the order of operations in the rotation extrapolation which could result in stutters.