### PR TITLE
chore: migrate to Bevy 0.19-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ libm = ["bevy/libm"]
 critical-section = ["bevy/critical-section"]
 
 [dependencies]
-bevy = { version = "0.18.0", default-features = false }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false }
 
 # Serialization
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = ["2d", "ui"] }
+bevy = { git = "https://github.com/bevyengine/bevy", default-features = false, features = ["2d", "ui"] }
 
 [lints.clippy]
 std_instead_of_core = "warn"


### PR DESCRIPTION
Bump bevy dep to Bevy 0.19-dev git.