### PR TITLE
correct crate version in `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ First, add `bevy_transform_interpolation` to your dependencies in `Cargo.toml`:
 
 ```toml
 [dependencies]
-bevy_transform_interpolation = "0.4"
+bevy_transform_interpolation = "0.5"
 ```
 
 To enable `Transform` interpolation, add the `TransformInterpolationPlugin` to your app:


### PR DESCRIPTION
# Objective

example to install the crate has version set to 0.4 -- could be a bit confusing since 0.5 is released.

## Solution

bumped version to 0.5 in example

## Changelog

N/A

## Migration Guide

N/A